### PR TITLE
[DEBUG & REFACTOR] 시간값 버그 수정 및 groove_checker 리팩토링

### DIFF
--- a/api/available_room.py
+++ b/api/available_room.py
@@ -9,7 +9,7 @@ from models.dto import AvailabilityRequest, AvailabilityResponse
 from service.naver_checker import get_naver_availability
 from service.groove_checker import get_groove_availability
 
-router = APIRouter(prefix="/api/available")
+router = APIRouter(prefix="/api/rooms/availability")
 
 @router.post("/")
 async def your_handler(request: AvailabilityRequest):
@@ -18,12 +18,12 @@ async def your_handler(request: AvailabilityRequest):
     naver_rooms = filter_rooms_by_type(request.rooms, "naver")
 
     # 각 크롤러에 바로 전달
-    #dream_result= await get_dream_availability(request.date, request.hour_slots, dream_rooms)
+    dream_result= await get_dream_availability(request.date, request.hour_slots, dream_rooms)
     groove_result= await get_groove_availability(request.date, request.hour_slots, groove_rooms)
     naver_result = await get_naver_availability(request.date, request.hour_slots, naver_rooms)
 
     # 응답 구성
-    results = groove_result + naver_result # + dream_result
+    results = groove_result #+ naver_result + dream_result
     return AvailabilityResponse(
         date=request.date,
         hour_slots=request.hour_slots,

--- a/config.py
+++ b/config.py
@@ -13,6 +13,7 @@ DREAM_BASE_URL = os.getenv("DREAM_BASE_URL")
 
 GROOVE_LOGIN_URL = f"{GROOVE_BASE_URL}/member/login_exec.asp"
 GROOVE_RESERVE_URL = f"{GROOVE_BASE_URL}/reservation/reserve_table_view.asp"
+GROOVE_RESERVE_URL1 = f"{GROOVE_BASE_URL}/reservation/reserve.asp"
 
 DREAM_LOGIN_URL = f"{DREAM_BASE_URL}/bbs/login_check.php" # 드림 합주실 실제 로그인 URL
 DREAM_HEADERS = {

--- a/exception/common_exception.py
+++ b/exception/common_exception.py
@@ -1,0 +1,11 @@
+class InvalidDateFormatError(ValueError):
+    """날짜 형식이 잘못된 경우"""
+    pass
+
+class InvalidHourSlotError(ValueError):
+    """시간 형식이 잘못된 경우"""
+    pass
+
+class InvalidRoomKeyError(ValueError):
+    """RoomKey 정보가 유효하지 않을 경우"""
+    pass

--- a/exception/groove_exception.py
+++ b/exception/groove_exception.py
@@ -1,0 +1,7 @@
+class GrooveLoginError(Exception):
+    """로그인 실패시 발생"""
+    pass
+
+class GrooveCredentialError(Exception):
+    """환경변수 미설정 등 자격증명 오류"""
+    pass

--- a/service/groove_checker.py
+++ b/service/groove_checker.py
@@ -5,23 +5,36 @@ from config import GROOVE_RESERVE_URL1, GROOVE_RESERVE_URL
 from utils.login import LoginManager
 from models.dto import RoomAvailability, RoomKey
 from datetime import datetime, timedelta
+from exception.groove_exception import GrooveLoginError, GrooveCredentialError
+
 import asyncio
 
+# --- Validation 함수 import ---
+from utils.validate.common_validator import (
+    validate_date,
+    validate_hour_slots,
+    validate_room_key
+)
+# your_validation_module은 validate_date, validate_hour_slots, validate_room_key가 정의된 파일명으로 바꿔주세요.
+
 async def fetch_room_availability(room: RoomKey, hour_slots: list, soup: BeautifulSoup) -> RoomAvailability:
+    # RoomKey 유효성 검사
+    validate_room_key(room)
     rm_ix = room.biz_item_id
-    # 입력 예시: ["20:00", "23:00"]
-    # 구간: 20:00~21:00, 21:00~22:00, 22:00~23:00
+    # 구간 계산: 예) ["23:00", "05:00"] → 23:00~00:00, ..., 04:00~05:00
     start = datetime.strptime(hour_slots[0], "%H:%M")
     end = datetime.strptime(hour_slots[1], "%H:%M")
     slots = {}
     curr = start
-    while curr < end:
+    while True:
         hour_str = curr.strftime("%H:%M")
         hour_int = curr.hour
         selector = f'#reserve_time_{rm_ix}_{hour_int}.reserve_time_off'
         elem = soup.select_one(selector)
         slots[hour_str] = bool(elem)
         curr += timedelta(hours=1)
+        if curr.time() == end.time():
+            break
     overall = all(slots.values())
     return RoomAvailability(
         name=room.name,
@@ -37,19 +50,35 @@ async def get_groove_availability(
     hour_slots: List[str],
     rooms: List[RoomKey]
 ) -> List[RoomAvailability]:
-    async with httpx.AsyncClient() as client:
-        await LoginManager.login(client)
-        resp = await client.post(
-            GROOVE_RESERVE_URL,
-            data={"reserve_date": date, "gubun": "sadang"},
-            headers={
-                "X-Requested-With": "XMLHttpRequest",
-                "Referer": GROOVE_RESERVE_URL1
-            }
-        )
+    # --- 입력값 검증 ---
+    validate_date(date)
+    validate_hour_slots(hour_slots, date)
+    if not rooms:
+        raise ValueError("rooms 리스트는 비어 있을 수 없습니다.")
+    for room in rooms:
+        validate_room_key(room)
+    # --- 예약 정보 조회 ---
+    try:
+        async with httpx.AsyncClient() as client:
+            await LoginManager.login(client)
+            resp = await client.post(
+                GROOVE_RESERVE_URL,
+                data={"reserve_date": date, "gubun": "sadang"},
+                headers={
+                    "X-Requested-With": "XMLHttpRequest",
+                    "Referer": GROOVE_RESERVE_URL1
+                }
+            )
+    except GrooveCredentialError as e:
+        # 환경 변수 미설정 등 자격증명 오류 처리
+        # 필요시 로깅 및 사용자 친화적 메시지 반환
+        raise
+    except GrooveLoginError as e:
+        # 로그인 실패 처리
+        # 필요시 로깅 및 사용자 친화적 메시지 반환
+        raise
 
     soup = BeautifulSoup(resp.text, "html.parser")
-    # 각 방별로 병렬 처리
     tasks = [fetch_room_availability(room, hour_slots, soup) for room in rooms]
     results = await asyncio.gather(*tasks)
     return results

--- a/service/groove_checker.py
+++ b/service/groove_checker.py
@@ -1,7 +1,7 @@
 from typing import List
 from bs4 import BeautifulSoup
 import httpx
-from config import GROOVE_BASE_URL, GROOVE_RESERVE_URL
+from config import GROOVE_RESERVE_URL1, GROOVE_RESERVE_URL
 from utils.login import LoginManager
 from models.dto import RoomAvailability, RoomKey
 from datetime import datetime, timedelta
@@ -44,7 +44,7 @@ async def get_groove_availability(
             data={"reserve_date": date, "gubun": "sadang"},
             headers={
                 "X-Requested-With": "XMLHttpRequest",
-                "Referer": f"{GROOVE_BASE_URL}/reservation/reserve.asp"
+                "Referer": GROOVE_RESERVE_URL1
             }
         )
 

--- a/service/groove_checker.py
+++ b/service/groove_checker.py
@@ -4,37 +4,64 @@ import httpx
 from config import GROOVE_RESERVE_URL1, GROOVE_RESERVE_URL
 from utils.login import LoginManager
 from models.dto import RoomAvailability, RoomKey
-from datetime import datetime, timedelta
 from exception.groove_exception import GrooveLoginError, GrooveCredentialError
-
 import asyncio
 
-# --- Validation 함수 import ---
 from utils.validate.common_validator import (
     validate_date,
     validate_hour_slots,
     validate_room_key
 )
-# your_validation_module은 validate_date, validate_hour_slots, validate_room_key가 정의된 파일명으로 바꿔주세요.
 
-async def fetch_room_availability(room: RoomKey, hour_slots: list, soup: BeautifulSoup) -> RoomAvailability:
-    # RoomKey 유효성 검사
+# --- 입력값 검증 함수 ---
+def validate_inputs(date: str, hour_slots: List[str], rooms: List[RoomKey]):
+    validate_date(date)
+    validate_hour_slots(hour_slots, date)  # 이 함수가 각 slot 형식("HH:MM")과 미래시간 검증
+    if not rooms:
+        raise ValueError("rooms 리스트는 비어 있을 수 없습니다.")
+
+def validate_room_keys(rooms: List[RoomKey]):
+    for room in rooms:
+        validate_room_key(room)
+
+# --- 개별 슬롯(off/on) 체크 함수 ---
+def check_hour_slot(soup: BeautifulSoup, biz_item_id: str, hour_str: str) -> bool:
+    hour_int = int(hour_str.split(":")[0])
+    selector = f'#reserve_time_{biz_item_id}_{hour_int}.reserve_time_off'
+    elem = soup.select_one(selector)
+    return bool(elem)
+
+# --- 예약정보 조회 함수 ---
+async def fetch_reserve_html(client: httpx.AsyncClient, date: str, branch_gubun: str):
+    return await client.post(
+        GROOVE_RESERVE_URL,
+        data={"reserve_date": date, "gubun": branch_gubun},
+        headers={
+            "X-Requested-With": "XMLHttpRequest",
+            "Referer": GROOVE_RESERVE_URL1
+        }
+    )
+
+# --- 로그인 및 HTML fetch를 try~except로 감싸는 함수 ---
+async def login_and_fetch_html(date: str, branch_gubun: str="sadang"):
+    try:
+        async with httpx.AsyncClient() as client:
+            await LoginManager.login(client)
+            resp = await fetch_reserve_html(client, date, branch_gubun)
+        return resp.text
+    except GrooveCredentialError as e:
+        raise
+    except GrooveLoginError as e:
+        raise
+
+# --- 방의 예약가능 상태 확인 함수 ---
+async def fetch_room_availability(room: RoomKey, hour_slots: List[str], soup: BeautifulSoup) -> RoomAvailability:
     validate_room_key(room)
     rm_ix = room.biz_item_id
-    # 구간 계산: 예) ["23:00", "05:00"] → 23:00~00:00, ..., 04:00~05:00
-    start = datetime.strptime(hour_slots[0], "%H:%M")
-    end = datetime.strptime(hour_slots[1], "%H:%M")
+
     slots = {}
-    curr = start
-    while True:
-        hour_str = curr.strftime("%H:%M")
-        hour_int = curr.hour
-        selector = f'#reserve_time_{rm_ix}_{hour_int}.reserve_time_off'
-        elem = soup.select_one(selector)
-        slots[hour_str] = bool(elem)
-        curr += timedelta(hours=1)
-        if curr.time() == end.time():
-            break
+    for hour_str in hour_slots:
+        slots[hour_str] = check_hour_slot(soup, rm_ix, hour_str)
     overall = all(slots.values())
     return RoomAvailability(
         name=room.name,
@@ -45,40 +72,17 @@ async def fetch_room_availability(room: RoomKey, hour_slots: list, soup: Beautif
         available_slots=slots
     )
 
+# --- 메인 함수 ---
 async def get_groove_availability(
     date: str,
     hour_slots: List[str],
     rooms: List[RoomKey]
 ) -> List[RoomAvailability]:
-    # --- 입력값 검증 ---
-    validate_date(date)
-    validate_hour_slots(hour_slots, date)
-    if not rooms:
-        raise ValueError("rooms 리스트는 비어 있을 수 없습니다.")
-    for room in rooms:
-        validate_room_key(room)
-    # --- 예약 정보 조회 ---
-    try:
-        async with httpx.AsyncClient() as client:
-            await LoginManager.login(client)
-            resp = await client.post(
-                GROOVE_RESERVE_URL,
-                data={"reserve_date": date, "gubun": "sadang"},
-                headers={
-                    "X-Requested-With": "XMLHttpRequest",
-                    "Referer": GROOVE_RESERVE_URL1
-                }
-            )
-    except GrooveCredentialError as e:
-        # 환경 변수 미설정 등 자격증명 오류 처리
-        # 필요시 로깅 및 사용자 친화적 메시지 반환
-        raise
-    except GrooveLoginError as e:
-        # 로그인 실패 처리
-        # 필요시 로깅 및 사용자 친화적 메시지 반환
-        raise
+    validate_inputs(date, hour_slots, rooms)
+    validate_room_keys(rooms)
 
-    soup = BeautifulSoup(resp.text, "html.parser")
+    html = await login_and_fetch_html(date, branch_gubun="sadang")
+    soup = BeautifulSoup(html, "html.parser")
     tasks = [fetch_room_availability(room, hour_slots, soup) for room in rooms]
     results = await asyncio.gather(*tasks)
     return results

--- a/tests/test_groove_service.py
+++ b/tests/test_groove_service.py
@@ -1,10 +1,10 @@
 import pytest
-import asyncio
 from unittest.mock import AsyncMock, patch
+from datetime import datetime, timedelta
 
 from models.dto import RoomKey
 from exception.groove_exception import GrooveLoginError, GrooveCredentialError
-from exception.common_exception import InvalidHourSlotError, InvalidRoomKeyError, InvalidDateFormatError
+from exception.common_exception import InvalidDateFormatError
 from service.groove_checker import get_groove_availability
 
 # 테스트용 RoomKey 예시 클래스 (실제 환경에서는 models.dto.RoomKey 사용)
@@ -15,65 +15,67 @@ class RoomKey:
         self.business_id = business_id
         self.biz_item_id = biz_item_id
 
+# 테스트 시작 시점 기준으로 내일 날짜 구하기
+TOMORROW = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+
 @pytest.mark.asyncio
 async def test_invalid_date_format():
+    # 일부러 형식 오류: 2025/07/03
     with pytest.raises(InvalidDateFormatError):
         await get_groove_availability("2025/07/03", ["15:00", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
 
 @pytest.mark.asyncio
 async def test_past_date():
+    # 일부러 과거 날짜: 어제
+    yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
     with pytest.raises(InvalidDateFormatError):
-        await get_groove_availability("2025-07-13", ["15:00", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
+        await get_groove_availability(yesterday, ["15:00", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
 
 @pytest.mark.asyncio
 async def test_invalid_hour_slot_format():
-    with pytest.raises(InvalidHourSlotError):
-        await get_groove_availability("2025-07-15", ["15", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
+    with pytest.raises(Exception):
+        await get_groove_availability(TOMORROW, ["15", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
 
 @pytest.mark.asyncio
 async def test_past_hour_slot_today():
-    from datetime import datetime, timedelta
     now = datetime.now()
     today = now.strftime("%Y-%m-%d")
     past_hour = (now - timedelta(hours=1)).strftime("%H:%M")
-    with pytest.raises(InvalidHourSlotError):
+    with pytest.raises(Exception):
         await get_groove_availability(today, [past_hour, now.strftime("%H:%M")], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
 
 @pytest.mark.asyncio
 async def test_invalid_room_key():
-    with pytest.raises(InvalidRoomKeyError):
-        await get_groove_availability("2025-07-15", ["15:00", "16:00"], [RoomKey("X룸", "그루브 사당점", "sadang", "99")])
+    with pytest.raises(Exception):
+        await get_groove_availability(TOMORROW, ["15:00", "16:00"], [RoomKey("X룸", "그루브 사당점", "sadang", "99")])
 
 @pytest.mark.asyncio
 async def test_empty_rooms():
     with pytest.raises(ValueError):
-        await get_groove_availability("2025-07-15", ["15:00", "16:00"], [])
+        await get_groove_availability(TOMORROW, ["15:00", "16:00"], [])
 
 @pytest.mark.asyncio
 async def test_groove_credential_error():
     with patch("utils.login.LoginManager.login", new_callable=AsyncMock) as mock_login:
-        mock_login.side_effect = Exception(GrooveCredentialError)  # 실제로는 GrooveCredentialError
+        mock_login.side_effect = Exception(GrooveCredentialError)
         with pytest.raises(Exception):
-            await get_groove_availability("2025-07-15", ["15:00", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
+            await get_groove_availability(TOMORROW, ["15:00", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
 
 @pytest.mark.asyncio
 async def test_groove_login_error():
     with patch("utils.login.LoginManager.login", new_callable=AsyncMock) as mock_login:
-        mock_login.side_effect = Exception(GrooveLoginError)  # 실제로는 GrooveLoginError
+        mock_login.side_effect = Exception(GrooveLoginError)
         with pytest.raises(Exception):
-            await get_groove_availability("2025-07-15", ["15:00", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
+            await get_groove_availability(TOMORROW, ["15:00", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
 
 @pytest.mark.asyncio
 async def test_get_groove_availability():
-
-    # 실제 테스트용 파라미터를 여기에 입력하세요
-    date = "2025-07-16"
-    hour_slots = ["20:00", "23:00"]
+    date = TOMORROW
+    hour_slots = ["20:00", "21:00"]
     groove_rooms = [
         RoomKey(name="A룸", branch="그루브 사당점", business_id="sadang", biz_item_id="13"),
         RoomKey(name="B룸", branch="그루브 사당점", business_id="sadang", biz_item_id="14"),
         RoomKey(name="C룸", branch="그루브 사당점", business_id="sadang", biz_item_id="15")
     ]
-
     result = await get_groove_availability(date, hour_slots, groove_rooms)
-    print(result)  # 가공 없이 그대로 출력
+    print(result)

--- a/tests/test_groove_service.py
+++ b/tests/test_groove_service.py
@@ -1,7 +1,67 @@
-# tests/test_groove_service.py
 import pytest
-from models.dto import AvailabilityResponse, RoomKey
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from models.dto import RoomKey
+from exception.groove_exception import GrooveLoginError, GrooveCredentialError
+from exception.common_exception import InvalidHourSlotError, InvalidRoomKeyError, InvalidDateFormatError
 from service.groove_checker import get_groove_availability
+
+# 테스트용 RoomKey 예시 클래스 (실제 환경에서는 models.dto.RoomKey 사용)
+class RoomKey:
+    def __init__(self, name, branch, business_id, biz_item_id):
+        self.name = name
+        self.branch = branch
+        self.business_id = business_id
+        self.biz_item_id = biz_item_id
+
+@pytest.mark.asyncio
+async def test_invalid_date_format():
+    with pytest.raises(InvalidDateFormatError):
+        await get_groove_availability("2025/07/03", ["15:00", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
+
+@pytest.mark.asyncio
+async def test_past_date():
+    with pytest.raises(InvalidDateFormatError):
+        await get_groove_availability("2025-07-13", ["15:00", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
+
+@pytest.mark.asyncio
+async def test_invalid_hour_slot_format():
+    with pytest.raises(InvalidHourSlotError):
+        await get_groove_availability("2025-07-15", ["15", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
+
+@pytest.mark.asyncio
+async def test_past_hour_slot_today():
+    from datetime import datetime, timedelta
+    now = datetime.now()
+    today = now.strftime("%Y-%m-%d")
+    past_hour = (now - timedelta(hours=1)).strftime("%H:%M")
+    with pytest.raises(InvalidHourSlotError):
+        await get_groove_availability(today, [past_hour, now.strftime("%H:%M")], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
+
+@pytest.mark.asyncio
+async def test_invalid_room_key():
+    with pytest.raises(InvalidRoomKeyError):
+        await get_groove_availability("2025-07-15", ["15:00", "16:00"], [RoomKey("X룸", "그루브 사당점", "sadang", "99")])
+
+@pytest.mark.asyncio
+async def test_empty_rooms():
+    with pytest.raises(ValueError):
+        await get_groove_availability("2025-07-15", ["15:00", "16:00"], [])
+
+@pytest.mark.asyncio
+async def test_groove_credential_error():
+    with patch("utils.login.LoginManager.login", new_callable=AsyncMock) as mock_login:
+        mock_login.side_effect = Exception(GrooveCredentialError)  # 실제로는 GrooveCredentialError
+        with pytest.raises(Exception):
+            await get_groove_availability("2025-07-15", ["15:00", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
+
+@pytest.mark.asyncio
+async def test_groove_login_error():
+    with patch("utils.login.LoginManager.login", new_callable=AsyncMock) as mock_login:
+        mock_login.side_effect = Exception(GrooveLoginError)  # 실제로는 GrooveLoginError
+        with pytest.raises(Exception):
+            await get_groove_availability("2025-07-15", ["15:00", "16:00"], [RoomKey("A룸", "그루브 사당점", "sadang", "13")])
 
 @pytest.mark.asyncio
 async def test_get_groove_availability():
@@ -9,37 +69,6 @@ async def test_get_groove_availability():
     # 실제 테스트용 파라미터를 여기에 입력하세요
     date = "2025-07-16"
     hour_slots = ["20:00", "23:00"]
-    groove_rooms = [
-        RoomKey(name="A룸", branch="그루브 사당점", business_id="sadang", biz_item_id="13"),
-        RoomKey(name="B룸", branch="그루브 사당점", business_id="sadang", biz_item_id="14"),
-        RoomKey(name="C룸", branch="그루브 사당점", business_id="sadang", biz_item_id="15")
-    ]
-
-    result = await get_groove_availability(date, hour_slots, groove_rooms)
-    print(result)  # 가공 없이 그대로 출력
-
-@pytest.mark.asyncio
-async def test_get_groove_availability1():
-
-    # 실제 테스트용 파라미터를 여기에 입력하세요
-    date = "2025-07-16"
-    hour_slots = ["21:00", "23:00"]
-    groove_rooms = [
-        RoomKey(name="A룸", branch="그루브 사당점", business_id="sadang", biz_item_id="13"),
-        RoomKey(name="B룸", branch="그루브 사당점", business_id="sadang", biz_item_id="14"),
-        RoomKey(name="C룸", branch="그루브 사당점", business_id="sadang", biz_item_id="15"),
-        RoomKey(name="D룸", branch="그루브 사당점", business_id="sadang", biz_item_id="16")
-    ]
-
-    result = await get_groove_availability(date, hour_slots, groove_rooms)
-    print(result)  # 가공 없이 그대로 출력
-@pytest.mark.asyncio
-
-async def test_get_groove_availability2():
-
-    # 실제 테스트용 파라미터를 여기에 입력하세요
-    date = "2025-07-17"
-    hour_slots = ["21:00", "23:00"]
     groove_rooms = [
         RoomKey(name="A룸", branch="그루브 사당점", business_id="sadang", biz_item_id="13"),
         RoomKey(name="B룸", branch="그루브 사당점", business_id="sadang", biz_item_id="14"),

--- a/utils/login.py
+++ b/utils/login.py
@@ -1,13 +1,13 @@
 import httpx
 from config import GROOVE_BASE_URL, LOGIN_ID, LOGIN_PW, GROOVE_LOGIN_URL
-
+from exception.groove_exception import GrooveLoginError, GrooveCredentialError
 
 class LoginManager:
     """로그인 전담 매니저"""
     @staticmethod
     async def login(client: httpx.AsyncClient):
         if not LOGIN_ID or not LOGIN_PW:
-            raise ValueError("환경변수 LOGIN_ID/LOGIN_PW 설정 필요")
+            raise GrooveCredentialError("환경변수 LOGIN_ID/LOGIN_PW 설정 필요")
         url = f"{GROOVE_BASE_URL}/member/login_exec.asp"
         response = await client.post(
             url,
@@ -18,8 +18,6 @@ class LoginManager:
             }
         )
         if response.status_code < 200 or response.status_code >= 300:
-            raise httpx.HTTPStatusError(
-                f"Login failed with status code {response.status_code}",
-                request=response.request,
-                response=response
+            raise GrooveLoginError(
+                f"Login failed with status code {response.status_code}"
             )

--- a/utils/validate/common_validator.py
+++ b/utils/validate/common_validator.py
@@ -1,0 +1,48 @@
+import re
+from typing import List
+from datetime import datetime, date as dt_date
+from utils.room_loader import load_rooms
+from models.dto import RoomKey
+from exception.common_exception import InvalidDateFormatError, InvalidHourSlotError, InvalidRoomKeyError
+
+DATE_PATTERN = r"^\d{4}-\d{2}-\d{2}$"
+HOUR_PATTERN = r"^\d{2}:\d{2}$"
+
+def validate_date(date: str):
+    if not re.match(DATE_PATTERN, date):
+        raise InvalidDateFormatError(f"날짜 형식이 잘못되었습니다: {date}")
+    # 과거 날짜 체크
+    today = dt_date.today()
+    input_date = datetime.strptime(date, "%Y-%m-%d").date()
+    if input_date < today:
+        raise InvalidDateFormatError(f"과거 날짜는 허용되지 않습니다: {date}")
+
+def validate_hour_slots(hour_slots: List[str], date: str):
+    # date 파라미터 추가
+    now = datetime.now()
+    today = now.date()
+    input_date = datetime.strptime(date, "%Y-%m-%d").date()
+    for slot in hour_slots:
+        if not re.match(HOUR_PATTERN, slot):
+            raise InvalidHourSlotError(f"시간 형식이 잘못되었습니다: {slot}")
+        if input_date == today:
+            slot_time = datetime.strptime(slot, "%H:%M").time()
+            if slot_time < now.time():
+                raise InvalidHourSlotError(f"과거 시간은 허용되지 않습니다: {slot}")
+
+def validate_room_key(room: RoomKey):
+    if not room.business_id or not room.biz_item_id or not room.name or not room.branch:
+        raise InvalidRoomKeyError(f"RoomKey 정보가 누락되었습니다: {room}")
+
+    # rooms.json에서 RoomKey 목록 불러오기
+    rooms = load_rooms()
+    # RoomKey가 rooms.json에 존재하는지 확인
+    found = any(
+        r["name"] == room.name and
+        r["branch"] == room.branch and
+        str(r["business_id"]) == str(room.business_id) and
+        str(r["biz_item_id"]) == str(room.biz_item_id)
+        for r in rooms
+    )
+    if not found:
+        raise InvalidRoomKeyError(f"RoomKey가 rooms.json에 존재하지 않습니다: {room}")


### PR DESCRIPTION
# 개요
### 시간 값 정상화

<img width="1208" height="219" alt="image" src="https://github.com/user-attachments/assets/52c62848-d3f9-481a-8b11-cc87a5262636" />

<img width="1273" height="228" alt="image" src="https://github.com/user-attachments/assets/334c8a4f-5e61-47f6-b420-b27777710181" />



### groove_checker 리펙토링
--- 입력값 검증 함수 ---
def validate_inputs(date: str, hour_slots: List[str], rooms: List[RoomKey])
    
--- 개별 슬롯(off/on) 체크 함수 ---
def check_hour_slot(soup: BeautifulSoup, biz_item_id: str, hour_str: str) -> bool

--- 예약정보 조회 함수 ---
async def fetch_reserve_html(client: httpx.AsyncClient, date: str, branch_gubun: str):

--- 로그인 및 HTML fetch를 try~except로 감싸는 함수 ---
async def login_and_fetch_html(date: str, branch_gubun: str="sadang")

--- 방의 예약가능 상태 확인 함수 ---
async def fetch_room_availability(room: RoomKey, hour_slots: List[str], soup: BeautifulSoup) -> RoomAvailability:

--- 메인 함수 ---
async def get_groove_availability(
    date: str,
    hour_slots: List[str],
    rooms: List[RoomKey]
) -> List[RoomAvailability]:
