### PR TITLE
[#95]; package: httpx 라이브러리(http2) 의존성 추가

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # ==== 런타임 필수 ====
 fastapi~=0.110
 uvicorn[standard]~=0.29
-httpx~=0.27
+httpx[http2]~=0.27
 beautifulsoup4~=4.12
 pydantic~=2.7
 


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #95

지난 91번 이슈 PR에서 리뷰 반영하여 **client_loader.py**에서 **http2=True 옵션을 사용**했습니다.
그런데 **requirements.txt에 해당 의존성 설치 부분을 추가하지 않은 점을 확인**했습니다.

기존에 가상환경을 활성화하지 않고 작업했던 것을 확인하여, 가상환경을 활성화했는데 ImportError가 발생했습니다. 
이에 따라 http2 의존성을 추가했습니다.

- [x]  requirements.txt: httpx -> httpx[http2] 로 변경하여 h2 라이브러리가 함께 설치되도록 수정하였습니다. (httpx[http2]는 기존에 설치했던 http 라이브러리와 추가할 http2 모두 설치할 수 있습니다.)
- [x] uvicorn app.main:app --reload 정상 구동 확인 완료했습니다.