### PR TITLE
[#163]; bug: 검색 결과 없음(empty rooms) 시 200 응답으로 처리

### DIFF
--- a/app/validate/request_validator.py
+++ b/app/validate/request_validator.py
@@ -20,7 +20,10 @@ def validate_availability_request(
     validate_hour_slots(hour_slots, date)
 
     # RoomKey 관련 모든 검증을 한 번에 처리
-    validate_room_detail_list(target_rooms)
+    # NOTE:
+    # 빈 target_rooms는 "검색 결과 없음" 정상 시나리오이므로 예외로 처리하지 않는다.
+    if target_rooms:
+        validate_room_detail_list(target_rooms)
 
 def validate_map_coordinates(swLat: float, swLng: float, neLat: float, neLng: float):
     """

--- a/tests/api/test_available_room.py
+++ b/tests/api/test_available_room.py
@@ -153,6 +153,29 @@ def test_get_availability_api():
         assert "branch_summary" in result
 
 
+def test_get_availability_api_no_result_returns_empty_success():
+    """검색 조건에 맞는 room이 없으면 200 + empty result를 반환해야 한다."""
+    url = "/api/rooms/availability"
+    target_date = (datetime.now() + timedelta(days=2)).strftime("%Y-%m-%d")
+
+    with patch(
+        "app.services.availability_service.get_rooms_by_criteria",
+        return_value=[],
+    ):
+        response = client.get(
+            f"{url}?date={target_date}&capacity=3&start_hour=18:00&end_hour=19:00&swLat=37.0&swLng=127.0&neLat=38.0&neLng=128.0"
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body.get("isSuccess") is True
+
+    result = body.get("result", {})
+    assert result.get("results") == []
+    assert result.get("available_biz_item_ids") == []
+    assert result.get("branch_summary") == {}
+
+
 def test_preflight_request():
     # CORS Preflight 요청 시뮬레이션
     habju = "https://www.pickhabju.com"

--- a/tests/validate/test_request_validator.py
+++ b/tests/validate/test_request_validator.py
@@ -1,0 +1,32 @@
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from app.validate.request_validator import validate_availability_request
+
+
+def _future_date(days: int = 2) -> str:
+    return (datetime.now() + timedelta(days=days)).strftime("%Y-%m-%d")
+
+
+def test_validate_availability_request_allows_empty_target_rooms():
+    """빈 room list는 no-result 정상 시나리오로 허용해야 한다."""
+    date = _future_date()
+    hour_slots = ["18:00", "19:00"]
+
+    with patch("app.validate.request_validator.validate_room_detail_list") as mock_validate:
+        validate_availability_request(date=date, hour_slots=hour_slots, target_rooms=[])
+        mock_validate.assert_not_called()
+
+
+def test_validate_availability_request_validates_room_list_when_present():
+    """room list가 존재하면 기존 room detail 검증을 수행해야 한다."""
+    date = _future_date()
+    hour_slots = ["18:00", "19:00"]
+
+    with patch("app.validate.request_validator.validate_room_detail_list") as mock_validate:
+        validate_availability_request(
+            date=date,
+            hour_slots=hour_slots,
+            target_rooms=[object()],
+        )
+        mock_validate.assert_called_once()


### PR DESCRIPTION
﻿## AS-IS
- availability 검증 단계에서 room list가 비어 있으면 `Room-003`(400) 예외가 발생했습니다.
- 사용자 관점의 no-result 시나리오가 오류로 처리되었습니다.

## TO-BE
- room list가 비어 있어도 정상 흐름으로 처리하여 200 + empty result를 반환합니다.
- 날짜/시간 검증은 그대로 유지합니다.

## 변경 사항
1. `app/validate/request_validator.py`
- `validate_availability_request`에서 `target_rooms`가 있을 때만 `validate_room_detail_list`를 호출하도록 변경

2. 테스트 추가
- `tests/validate/test_request_validator.py`
  - empty room list 허용
  - room list 존재 시 기존 검증 호출 유지
- `tests/api/test_available_room.py`
  - no-result 시 200 + empty result 회귀 테스트 추가

## 테스트
- `python -m pytest tests/validate/test_request_validator.py tests/api/test_available_room.py -k "no_result or validate_availability_request"`
- 결과: 3 passed

Closes #163
