### PR TITLE
[#165]; fix: NaverRoomFetcher timeout 환경변수 일관 적용

### DIFF
--- a/app/crawler/naver_room_fetcher.py
+++ b/app/crawler/naver_room_fetcher.py
@@ -79,7 +79,12 @@ class NaverRoomFetcher:
             "query": query
         }
 
-        resp = await client.post(self.GRAPHQL_URL, json=payload, headers=self.HEADERS, timeout=10.0)
+        resp = await client.post(
+            self.GRAPHQL_URL,
+            json=payload,
+            headers=self.HEADERS,
+            timeout=self.REQUEST_TIMEOUT,
+        )
         if resp.status_code != 200:
             logger.error(f"Business Error: {resp.status_code}, Body: {resp.text}")
         resp.raise_for_status()
@@ -128,7 +133,12 @@ class NaverRoomFetcher:
             "query": query
         }
         
-        resp = await client.post(self.GRAPHQL_URL, json=payload, headers=self.HEADERS, timeout=10.0)
+        resp = await client.post(
+            self.GRAPHQL_URL,
+            json=payload,
+            headers=self.HEADERS,
+            timeout=self.REQUEST_TIMEOUT,
+        )
         if resp.status_code != 200:
             logger.error(f"BizItems Error: {resp.status_code}, Body: {resp.text}")
         resp.raise_for_status()
@@ -171,7 +181,12 @@ class NaverRoomFetcher:
         }
         
         try:
-            resp = await client.post(self.GRAPHQL_URL, json=payload, headers=self.HEADERS, timeout=5.0)
+            resp = await client.post(
+                self.GRAPHQL_URL,
+                json=payload,
+                headers=self.HEADERS,
+                timeout=self.REQUEST_TIMEOUT,
+            )
             if resp.status_code != 200:
                 return None
             data = resp.json()

--- a/tests/crawler/test_naver_room_fetcher.py
+++ b/tests/crawler/test_naver_room_fetcher.py
@@ -1,0 +1,68 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.crawler.naver_room_fetcher import NaverRoomFetcher
+
+
+class _DummyResponse:
+    def __init__(self, data: dict, status_code: int = 200):
+        self._data = data
+        self.status_code = status_code
+        self.text = ""
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._data
+
+
+@pytest.mark.asyncio
+async def test_fetch_business_uses_request_timeout():
+    fetcher = NaverRoomFetcher()
+    fetcher.REQUEST_TIMEOUT = 3.5
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _DummyResponse(
+        {
+            "data": {
+                "business": {
+                    "businessId": "522011",
+                    "coordinates": [127.0, 37.0],
+                }
+            }
+        }
+    )
+
+    await fetcher._fetch_business(mock_client, "522011")
+
+    assert mock_client.post.await_args.kwargs["timeout"] == 3.5
+
+
+@pytest.mark.asyncio
+async def test_fetch_biz_items_uses_request_timeout():
+    fetcher = NaverRoomFetcher()
+    fetcher.REQUEST_TIMEOUT = 4.2
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _DummyResponse({"data": {"bizItems": []}})
+
+    await fetcher._fetch_biz_items(mock_client, "522011")
+
+    assert mock_client.post.await_args.kwargs["timeout"] == 4.2
+
+
+@pytest.mark.asyncio
+async def test_fetch_near_subway_uses_request_timeout():
+    fetcher = NaverRoomFetcher()
+    fetcher.REQUEST_TIMEOUT = 5.7
+
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _DummyResponse(
+        {"data": {"nearSubway": {"displayName": "홍대입구역"}}}
+    )
+
+    await fetcher._fetch_near_subway(mock_client, 37.0, 127.0, "place-id")
+
+    assert mock_client.post.await_args.kwargs["timeout"] == 5.7


### PR DESCRIPTION
﻿## AS-IS
- `NaverRoomFetcher`에 `REQUEST_TIMEOUT` 클래스 변수가 존재하지만,
  실제 GraphQL 호출 3개 메서드에서 `timeout=10.0`, `timeout=5.0` 하드코딩을 사용 중이었습니다.

## TO-BE
- `_fetch_business`, `_fetch_biz_items`, `_fetch_near_subway` 모두 `self.REQUEST_TIMEOUT`을 사용하도록 통일했습니다.
- `FETCHER_TIMEOUT` 환경변수 하나로 timeout 제어가 가능해집니다.

## 변경 사항
1. `app/crawler/naver_room_fetcher.py`
- GraphQL POST 호출 3곳 timeout 값을 `self.REQUEST_TIMEOUT`으로 변경

2. `tests/crawler/test_naver_room_fetcher.py`
- 각 메서드가 `REQUEST_TIMEOUT`을 실제 호출 파라미터로 사용하는지 검증하는 회귀 테스트 추가

## 테스트
- `python -m pytest tests/crawler/test_naver_room_fetcher.py -v`
- 결과: 3 passed

Closes #165
