### PR TITLE
fix: _merge_results id 누락 payload 방어

### DIFF
--- a/app/crawler/naver_map_crawler.py
+++ b/app/crawler/naver_map_crawler.py
@@ -133,8 +133,12 @@ class NaverMapCrawler:
             if not isinstance(item, dict):
                 logger.warning(f"Skipping non-dict item: {item}")
                 continue
-            if item["id"] not in target:
-                target[item["id"]] = item
+            item_id = item.get("id")
+            if not item_id:
+                logger.warning(f"Skipping item without 'id': {list(item.keys())[:3]}")
+                continue
+            if item_id not in target:
+                target[item_id] = item
 
     async def crawl_all_regions(self) -> List[Dict]:
         """

--- a/tests/crawler/test_naver_map_crawler.py
+++ b/tests/crawler/test_naver_map_crawler.py
@@ -1,108 +1,105 @@
 # tests/crawler/test_naver_map_crawler.py
 """
-NaverMapCrawler 단위 테스트
+NaverMapCrawler unit tests
 
-테스트 대상:
-- _merge_results: 중복 제거하며 결과 병합
-
-실행: pytest tests/crawler/test_naver_map_crawler.py -v
+Run:
+    pytest tests/crawler/test_naver_map_crawler.py -v
 """
 
 import pytest
+
 from app.crawler.naver_map_crawler import NaverMapCrawler
 
 
 class TestMergeResults:
-    """_merge_results 메서드 테스트"""
-    
     @pytest.fixture
     def crawler(self):
         return NaverMapCrawler(headless=True)
-    
-    # ============== TC: 기본 병합 ==============
+
     def test_basic_merge(self, crawler):
-        """새로운 아이템들이 target에 추가됨"""
         target = {}
         source = [
             {"id": "1", "name": "Room A"},
-            {"id": "2", "name": "Room B"}
+            {"id": "2", "name": "Room B"},
         ]
-        
+
         crawler._merge_results(target, source)
-        
+
         assert len(target) == 2
         assert target["1"]["name"] == "Room A"
         assert target["2"]["name"] == "Room B"
-    
-    # ============== TC: 중복 제거 ==============
+
     def test_deduplication(self, crawler):
-        """이미 존재하는 ID는 추가되지 않음"""
         target = {"1": {"id": "1", "name": "Existing Room"}}
         source = [
-            {"id": "1", "name": "Duplicate Room"},  # 중복
-            {"id": "2", "name": "New Room"}
+            {"id": "1", "name": "Duplicate Room"},
+            {"id": "2", "name": "New Room"},
         ]
-        
+
         crawler._merge_results(target, source)
-        
+
         assert len(target) == 2
-        assert target["1"]["name"] == "Existing Room"  # 기존 값 유지
+        assert target["1"]["name"] == "Existing Room"
         assert target["2"]["name"] == "New Room"
-    
-    # ============== TC: 빈 source ==============
+
     def test_empty_source(self, crawler):
-        """source가 비어있으면 target 변경 없음"""
         target = {"1": {"id": "1", "name": "Room A"}}
         source = []
-        
+
         crawler._merge_results(target, source)
-        
+
         assert len(target) == 1
-    
-    # ============== TC: 비정상 아이템 스킵 ==============
+
     def test_skip_non_dict_items(self, crawler):
-        """dict가 아닌 아이템은 스킵"""
         target = {}
         source = [
             {"id": "1", "name": "Room A"},
-            "invalid_string",  # 비정상
-            123,               # 비정상
-            {"id": "2", "name": "Room B"}
+            "invalid_string",
+            123,
+            {"id": "2", "name": "Room B"},
         ]
-        
+
         crawler._merge_results(target, source)
-        
+
         assert len(target) == 2
         assert "1" in target
         assert "2" in target
-    
-    # ============== TC: 연속 병합 ==============
-    def test_multiple_merges(self, crawler):
-        """여러 번 병합해도 중복 없이 누적"""
+
+    def test_skip_dict_without_id(self, crawler):
         target = {}
-        
+        source = [
+            {"id": "1", "name": "Room A"},
+            {"name": "Missing ID"},
+            {},
+            {"id": None, "name": "Invalid ID"},
+            {"id": "2", "name": "Room B"},
+        ]
+
+        crawler._merge_results(target, source)
+
+        assert len(target) == 2
+        assert "1" in target
+        assert "2" in target
+
+    def test_multiple_merges(self, crawler):
+        target = {}
+
         crawler._merge_results(target, [{"id": "1", "name": "Room A"}])
         crawler._merge_results(target, [{"id": "2", "name": "Room B"}])
-        crawler._merge_results(target, [{"id": "1", "name": "Duplicate A"}])  # 중복
-        
+        crawler._merge_results(target, [{"id": "1", "name": "Duplicate A"}])
+
         assert len(target) == 2
-        assert target["1"]["name"] == "Room A"  # 첫 번째 값 유지
+        assert target["1"]["name"] == "Room A"
 
 
 class TestRegionList:
-    """전국 지역 목록 테스트"""
-    
     @pytest.fixture
     def crawler(self):
         return NaverMapCrawler(headless=True)
-    
+
     def test_region_count(self, crawler):
-        """서울 25개 구 + 광역시 10개 = 35개 지역"""
-        # crawl_all_regions 메서드 내부의 all_queries 확인
-        # (직접 접근이 어려우므로 코드 리뷰 차원에서만 확인)
-        # 현재 구현에서는 35개 지역이 정의됨
         seoul_count = 25
         major_cities_count = 10
         expected_total = seoul_count + major_cities_count
-        
+
         assert expected_total == 35


### PR DESCRIPTION
﻿## 요약
- `_merge_results`에서 `item["id"]` 직접 접근을 제거하고 안전 접근(`get`)으로 변경
- `id` 누락/비정상 payload는 warning 로그 후 skip 처리
- 회귀 테스트 보강 (`non-dict`, `id` 누락 dict`)

## 변경 상세
- `app/crawler/naver_map_crawler.py`
  - `item_id = item.get("id")`
  - `id`가 없거나 falsy면 `logger.warning` 후 continue
- `tests/crawler/test_naver_map_crawler.py`
  - `test_skip_dict_without_id` 추가
  - 테스트 파일 문자열 깨짐/가독성 정리

## 테스트
- `python -m pytest tests/crawler/test_naver_map_crawler.py -v`

## 이슈
- closes #167
