### PR TITLE
[#175]; fix: db 예약 조건 컬럼명 미스매치로 인한 누락 픽스 및 fallback 방어 로직 추가

### DIFF
--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -230,6 +230,15 @@ class RoomCollectionService:
             final_base_cap = parsed["base_capacity"] if "base_capacity" in parsed else existing_base_cap
             final_extra_charge = parsed["extra_charge"] if "extra_charge" in parsed else existing_extra_charge
 
+            # Boolean fields fallback
+            existing_can_reserve = existing.get("can_reserve_one_hour", True) if existing else True
+            parsed_can_reserve = parsed.get("can_reserve_one_hour")
+            final_can_reserve = parsed_can_reserve if parsed_can_reserve is not None else existing_can_reserve
+            
+            existing_requires_call = existing.get("requires_call_on_sameday", False) if existing else False
+            parsed_requires_call = parsed.get("requires_call_on_same_day")
+            final_requires_call = parsed_requires_call if parsed_requires_call is not None else existing_requires_call
+
             # Room Data
             room_data = {
                 "business_id": business["businessId"],
@@ -250,7 +259,8 @@ class RoomCollectionService:
                 "price_config": final_price_config,
                 "base_capacity": final_base_cap,
                 "extra_charge": final_extra_charge,
-                "requires_call_on_sameday": parsed.get("requires_call_on_same_day") or False,
+                "requires_call_on_sameday": final_requires_call,
+                "can_reserve_one_hour": final_can_reserve,
                 "image_urls": image_urls  # Save to JSONB column
             }
             

--- a/app/services/room_parser_service.py
+++ b/app/services/room_parser_service.py
@@ -249,6 +249,11 @@ class RoomParserService:
         can_reserve_1h = result.get("can_reserve_one_hour")
         if can_reserve_1h is not None and not isinstance(can_reserve_1h, bool):
             return False
+            
+        # 8. requires_call_on_same_day 검증
+        requires_call_today = result.get("requires_call_on_same_day")
+        if requires_call_today is not None and not isinstance(requires_call_today, bool):
+            return False
         
         return True
 

--- a/app/services/room_parser_service.py
+++ b/app/services/room_parser_service.py
@@ -37,15 +37,15 @@ ROOM_PARSE_PROMPT = """Extract room info as JSON.
 
 Example 1:
 Input: "[평일] 블랙룸", "최대 8명, 4~6인 권장"
-Output: {{"clean_name": "블랙룸", "day_type": "weekday", "max_capacity": 8, "recommend_capacity": 5, "recommend_capacity_range": [4, 6], "base_capacity": null, "extra_charge": null, "requires_call_on_same_day": false}}
+Output: {{"clean_name": "블랙룸", "day_type": "weekday", "max_capacity": 8, "recommend_capacity": 5, "recommend_capacity_range": [4, 6], "base_capacity": null, "extra_charge": null, "requires_call_on_same_day": false, "can_reserve_one_hour": true}}
 
 Example 2:
 Input: "화이트룸", "기본 4인, 인당 3000원 추가"
-Output: {{"clean_name": "화이트룸", "day_type": null, "max_capacity": null, "recommend_capacity": null, "recommend_capacity_range": null, "base_capacity": 4, "extra_charge": 3000, "requires_call_on_same_day": false}}
+Output: {{"clean_name": "화이트룸", "day_type": null, "max_capacity": null, "recommend_capacity": null, "recommend_capacity_range": null, "base_capacity": 4, "extra_charge": 3000, "requires_call_on_same_day": false, "can_reserve_one_hour": true}}
 
 Example 3:
-Input: "[주말] 스튜디오A", "당일 예약은 전화 문의"
-Output: {{"clean_name": "스튜디오A", "day_type": "weekend", "max_capacity": null, "recommend_capacity": null, "recommend_capacity_range": null, "base_capacity": null, "extra_charge": null, "requires_call_on_same_day": true}}
+Input: "[주말] 스튜디오A", "당일 예약은 전화 문의, 최소 2시간부터 예약"
+Output: {{"clean_name": "스튜디오A", "day_type": "weekend", "max_capacity": null, "recommend_capacity": null, "recommend_capacity_range": null, "base_capacity": null, "extra_charge": null, "requires_call_on_same_day": true, "can_reserve_one_hour": false}}
 
 Rules:
 - clean_name: Remove tags like [평일], (주말) from name
@@ -56,6 +56,7 @@ Rules:
 - base_capacity: Base people count for pricing
 - extra_charge: Extra charge per person (number only, no currency)
 - requires_call_on_same_day: true if "당일" and ("전화" or "문의") found
+- can_reserve_one_hour: false if "최소 2시간", "1시간 예약 불가" found, otherwise true
 
 Now extract:
 Input: "{name}", "{desc}"
@@ -76,6 +77,7 @@ Rules:
 - base_capacity: Base people count for pricing
 - extra_charge: Extra charge per person (number only)
 - requires_call_on_same_day: true if "당일" and ("전화" or "문의") found
+- can_reserve_one_hour: false if "최소 2시간", "1시간 예약 불가" found, otherwise true
 
 Rooms:
 {rooms_text}
@@ -242,6 +244,11 @@ class RoomParserService:
                 return False
             if rec_range[0] < 1 or rec_range[1] > 50 or rec_range[0] > rec_range[1]:
                 return False
+                
+        # 7. can_reserve_one_hour 검증
+        can_reserve_1h = result.get("can_reserve_one_hour")
+        if can_reserve_1h is not None and not isinstance(can_reserve_1h, bool):
+            return False
         
         return True
 
@@ -312,6 +319,11 @@ class RoomParserService:
         # 4. Same day call
         requires_call = "당일" in desc and ("전화" in desc or "문의" in desc)
 
+        # 5. One hour reservation
+        can_reserve_1h = True
+        if "최소 2시간" in desc or "최소2시간" in desc or "1시간 불가" in desc or "1시간 예약 불가" in desc or ("1시간" in desc and "불가" in desc):
+            can_reserve_1h = False
+
         # [v2.0.0] recommend_capacity_range 구성
         # Rationale: 범위 정보가 있으면 [min, max]로, 단일 값이면 [n, n]으로 변환
         rec_range = parsed_range  # 범위 추출 결과가 있으면 그대로 사용
@@ -326,7 +338,8 @@ class RoomParserService:
             "recommend_capacity_range": rec_range,
             "base_capacity": base_cap,
             "extra_charge": extra_charge,
-            "requires_call_on_same_day": requires_call
+            "requires_call_on_same_day": requires_call,
+            "can_reserve_one_hour": can_reserve_1h
         }
 
     def _extract_capacity_from_text(self, text: str) -> tuple[Optional[int], Optional[int], Optional[list]]:

--- a/app/services/room_parser_service.py
+++ b/app/services/room_parser_service.py
@@ -326,7 +326,12 @@ class RoomParserService:
 
         # 5. One hour reservation
         can_reserve_1h = True
-        if "최소 2시간" in desc or "최소2시간" in desc or "1시간 불가" in desc or "1시간 예약 불가" in desc or ("1시간" in desc and "불가" in desc):
+        if (
+            "최소 2시간" in desc or "최소2시간" in desc or 
+            "2시간 이상" in desc or "2시간 이상만" in desc or 
+            "1시간 불가" in desc or "1시간 예약 불가" in desc or 
+            ("1시간" in desc and "불가" in desc)
+        ):
             can_reserve_1h = False
 
         # [v2.0.0] recommend_capacity_range 구성

--- a/tests/integration/test_supabase_repository.py
+++ b/tests/integration/test_supabase_repository.py
@@ -6,6 +6,12 @@ from app.repositories.supabase_repository import SupabaseFavoriteRepository
 # Load environment variables
 load_dotenv()
 
+RUN_EXTERNAL_TESTS = os.getenv("RUN_EXTERNAL_TESTS") == "1"
+pytestmark = pytest.mark.skipif(
+    not RUN_EXTERNAL_TESTS,
+    reason="External integration test disabled. Set RUN_EXTERNAL_TESTS=1 to run.",
+)
+
 @pytest.fixture
 def repo():
     """Real Supabase Repository instance"""

--- a/tests/services/test_room_collection_service.py
+++ b/tests/services/test_room_collection_service.py
@@ -204,6 +204,63 @@ class TestDataPreservationLogic:
         
         assert upsert_data["price_per_hour"] == 25000  # 기존 가격 유지
 
+    # ============== TC: 불리언 필드 보존 로직 ==============
+    @pytest.mark.asyncio
+    async def test_preserve_boolean_fields(self, service, mock_supabase):
+        """파서에서 추출하지 못한 불리언(None)은 대상 기존(DB)의 불리언 값 유지"""
+        mock_supabase._room_table.select.return_value.eq.return_value.execute.return_value = MagicMock(
+            data=[{"biz_item_id": "room1", "can_reserve_one_hour": False, "requires_call_on_sameday": True}]
+        )
+        
+        business = {"businessId": "biz1", "businessDisplayName": "테스트 합주실"}
+        rooms = [{"bizItemId": "room1", "name": "룸1", "bizItemResources": [], "minMaxPrice": {"minPrice": 15000}}]
+        # 파싱 결과에 None으로 명시되거나 아예 키가 없는 경우
+        parsed_results = {
+            "room1": {
+                "max_capacity": 5, 
+                "recommend_capacity": 4, 
+                "can_reserve_one_hour": None, 
+                "requires_call_on_same_day": None
+            }
+        }
+        
+        await service._save_to_db(business, rooms, parsed_results)
+        
+        upsert_call = mock_supabase._room_table.upsert.call_args_list[-1]
+        upsert_data = upsert_call[0][0]
+        
+        # 기존 데이터를 유지해야 함
+        assert upsert_data["can_reserve_one_hour"] is False
+        assert upsert_data["requires_call_on_sameday"] is True
+
+    @pytest.mark.asyncio
+    async def test_override_boolean_fields(self, service, mock_supabase):
+        """파서에서 추출한 명시적 불리언(False/True)은 기존 DB를 덮어씀"""
+        mock_supabase._room_table.select.return_value.eq.return_value.execute.return_value = MagicMock(
+            data=[{"biz_item_id": "room1", "can_reserve_one_hour": True, "requires_call_on_sameday": False}]
+        )
+        
+        business = {"businessId": "biz1", "businessDisplayName": "테스트 합주실"}
+        rooms = [{"bizItemId": "room1", "name": "룸1", "bizItemResources": [], "minMaxPrice": {"minPrice": 15000}}]
+        
+        parsed_results = {
+            "room1": {
+                "max_capacity": 5, 
+                "recommend_capacity": 4, 
+                "can_reserve_one_hour": False, # 새로 파싱됨
+                "requires_call_on_same_day": True # 새로 파싱됨
+            }
+        }
+        
+        await service._save_to_db(business, rooms, parsed_results)
+        
+        upsert_call = mock_supabase._room_table.upsert.call_args_list[-1]
+        upsert_data = upsert_call[0][0]
+        
+        # 새로운 값으로 덮어써야 함
+        assert upsert_data["can_reserve_one_hour"] is False
+        assert upsert_data["requires_call_on_sameday"] is True
+
 
 class TestV2NewFields:
     """[v2.0.0] 신규 필드(recommend_capacity_range, price_config, display_name) 저장 검증"""

--- a/tests/services/test_room_parser_service.py
+++ b/tests/services/test_room_parser_service.py
@@ -63,6 +63,23 @@ class TestParseWithRegex:
         result = parser._parse_with_regex("레드룸", "당일 예약은 전화 문의 바랍니다")
         
         assert result["requires_call_on_same_day"] is True
+        
+    # ============== TC: 최소 2시간 예약 감지 ==============
+    def test_cannot_reserve_one_hour(self, parser):
+        """1시간 예약 불가 감지 ("최소 2시간" 등)"""
+        result = parser._parse_with_regex("블루룸", "최소 2시간부터 예약 가능합니다")
+        assert result["can_reserve_one_hour"] is False
+
+    def test_cannot_reserve_one_hour_alternative(self, parser):
+        """1시간 예약 불가 대체 표현 감지"""
+        result = parser._parse_with_regex("그린룸", "1시간 단위 예약 불가")
+        assert result["can_reserve_one_hour"] is False
+
+    # ============== TC: 기본 1시간 예약 가능 ==============
+    def test_can_reserve_one_hour_default(self, parser):
+        """특별한 언급이 없으면 기본적으로 1시간 예약 가능"""
+        result = parser._parse_with_regex("옐로우룸", "쾌적한 합주 공간")
+        assert result.get("can_reserve_one_hour") is True
     
     # ============== TC05: 빈 설명 처리 ==============
     def test_empty_description(self, parser):

--- a/tests/services/test_room_parser_service.py
+++ b/tests/services/test_room_parser_service.py
@@ -75,6 +75,16 @@ class TestParseWithRegex:
         result = parser._parse_with_regex("그린룸", "1시간 단위 예약 불가")
         assert result["can_reserve_one_hour"] is False
 
+    def test_cannot_reserve_one_hour_2_hours_or_more(self, parser):
+        """'2시간 이상' 표현 감지"""
+        result = parser._parse_with_regex("오렌지룸", "2시간 이상 예약 가능")
+        assert result["can_reserve_one_hour"] is False
+
+    def test_cannot_reserve_one_hour_2_hours_or_more_only(self, parser):
+        """'2시간 이상만' 표현 감지"""
+        result = parser._parse_with_regex("퍼플룸", "이용은 2시간 이상만 가능합니다")
+        assert result["can_reserve_one_hour"] is False
+
     # ============== TC: 기본 1시간 예약 가능 ==============
     def test_can_reserve_one_hour_default(self, parser):
         """특별한 언급이 없으면 기본적으로 1시간 예약 가능"""
@@ -310,6 +320,16 @@ class TestValidateParsedResult:
     def test_invalid_capacity_range_too_high(self, parser):
         """비현실적 범위 (최대 50 초과)"""
         result = {"clean_name": "룸", "recommend_capacity_range": [4, 100]}
+        assert parser._validate_parsed_result(result) is False
+
+    def test_invalid_can_reserve_one_hour_type(self, parser):
+        """can_reserve_one_hour 값이 불리언이 아닌 경우"""
+        result = {"clean_name": "룸", "can_reserve_one_hour": "True"}
+        assert parser._validate_parsed_result(result) is False
+
+    def test_invalid_requires_call_on_same_day_type(self, parser):
+        """requires_call_on_same_day 값이 불리언이 아닌 경우"""
+        result = {"clean_name": "룸", "requires_call_on_same_day": "False"}
         assert parser._validate_parsed_result(result) is False
 
 

--- a/tests/test_naver_checker.py
+++ b/tests/test_naver_checker.py
@@ -1,10 +1,17 @@
 # te/test_naver_checker.py
 import pytest
+import os
 
 from datetime import datetime, timedelta
 from app.crawler.naver_checker import NaverCrawler
 from app.models.dto import RoomDetail
 from app.utils.room_loader import get_rooms_by_criteria
+
+RUN_EXTERNAL_TESTS = os.getenv("RUN_EXTERNAL_TESTS") == "1"
+pytestmark = pytest.mark.skipif(
+    not RUN_EXTERNAL_TESTS,
+    reason="External crawler test disabled. Set RUN_EXTERNAL_TESTS=1 to run.",
+)
 
 @pytest.mark.asyncio
 async def test_get_naver_availability():


### PR DESCRIPTION
Closes #175 

## 영향 범위
<!-- 이 변경사항이 영향을 미치는 범위를 작성해주세요 -->
- [RoomCollectionService]의 DB Room 정보 Upsert 로직
- [RoomParserService]의 LLM 및 Regex 파싱 로직

## 구현 내용
<!-- 구현하려는 기능이나 수정하려는 내용을 간결하게 작성해주세요 -->
### AS-IS
- [RoomCollectionService]의 upsert 로직에서 `can_reserve_one_hour`와 `requires_call_on_sameday` 필드를 DB에 명시적으로 넘겨주지 않거나 null로 전달하여, 기존에 크롤링된 유효한 값들이 덮어씌워지거나 1시간 예약 불가(false)인 매장이 기본값(true)으로 초기화되는 버그가 있었습니다.
- [RoomParserService]에서 각 합주실의 설명(desc) 텍스트로부터 1시간 예약 가능 여부(`can_reserve_one_hour`)를 추출하는 로직이 누락되어 있었습니다.

### TO-BE
- [x] [RoomParserService]의 LLM Prompt와 Regex Fallback에 "최소 2시간", "1시간 예약 불가" 등의 문구를 분석하여 `can_reserve_one_hour` 값을 적극적으로 파싱하도록 로직 추가
- [x] [RoomCollectionService의 upsert 시, 파서가 제공한 불리언(Boolean) 값이 있으면 이를 사용하고, 없으면 기존 DB 값을 보존하도록 방어적 병합(Fallback) 로직 추가 적용
- [x] 관련된 테스트 코드가 정상적으로 통과하는지 검증 (`test_room_parser_service`, `test_room_collection_service`)

## 특이사항
- 이번 패치 이후 새로 크롤링되거나 갱신되는 합주실 정보부터 예약 정책(1시간 불가 등)이 정상적으로 DB에 반영됩니다.
- 기존에 이미 잘못된 기본값(true)으로 덮어씌워진 채 저장된 합주실 데이터가 있다면, 추후 크롤러 스케줄러가 돌면서 자동 정정될 것으로 기대합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parsing now detects whether one-hour reservations are allowed and includes this field in parsed room data.

* **Bug Fixes**
  * Boolean booking flags (one-hour and same-day call requirement) preserve existing values when parser omits them and are overridden when parser provides explicit values.
  * Final parsed boolean values are applied consistently when saving room data.

* **Tests**
  * Added unit tests for one-hour parsing patterns and boolean preserve-vs-override behavior.
  * External integration tests are now gated by an environment flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->