### PR TITLE
hotfix; 160번 PR 머지 안 되는 거 해결

### DIFF
--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -42,7 +42,7 @@ def get_favorite_repository() -> IFavoriteRepository:
 
 
 def validate_device_id(
-    x_device_id: str | None = Header(default=None, alias="X-Device-Id")
+    x_device_id: str = Header(..., alias="X-Device-Id")
 ) -> str:
     """
     X-Device-Id 헤더 검증 및 반환 Dependency

--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ from app.exception.envelope_handlers import (
     validation_exception_handler,
 )
 from app.utils.client_loader import close_global_client, set_global_client
+from pydantic import ValidationError
 
 
 @asynccontextmanager
@@ -104,6 +105,7 @@ app.add_exception_handler(BaseCustomException, custom_exception_handler)
 
 # 3. 검증 예외
 app.add_exception_handler(RequestValidationError, validation_exception_handler)
+app.add_exception_handler(ValidationError, validation_exception_handler)
 
 # 4. HTTP 예외
 app.add_exception_handler(HTTPException, http_exception_handler)

--- a/app/models/dto.py
+++ b/app/models/dto.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel, Field, ConfigDict, field_validator
+from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator
 from typing import List, Dict, Union, Any, Optional
+import re
+from datetime import datetime, date
 
 # Room Information DTO (DB Query Result)
 class RoomDetail(BaseModel):
@@ -66,6 +68,74 @@ class AvailabilityRequest(BaseModel):
     swLng: float = Field(..., description="South-West Longitude")
     neLat: float = Field(..., description="North-East Latitude")
     neLng: float = Field(..., description="North-East Longitude")
+
+    @field_validator('date')
+    @classmethod
+    def validate_date_format(cls, v: str) -> str:
+        # 1. Regex Format Check
+        if not re.match(r"^\d{4}-\d{2}-\d{2}$", v):
+            raise ValueError("날짜 형식이 올바르지 않습니다. (YYYY-MM-DD)")
+        
+        # 2. Calendar Validity Check (e.g., 2024-02-30)
+        try:
+            input_date = datetime.strptime(v, "%Y-%m-%d").date()
+        except ValueError:
+            raise ValueError("날짜 형식이 올바르지 않습니다. (YYYY-MM-DD)")
+            
+        # 3. Logic Check (Past Date)
+        if input_date < date.today():
+            raise ValueError("과거 날짜는 예약할 수 없습니다.")
+            
+        return v
+    
+    @field_validator('start_hour', 'end_hour')
+    @classmethod
+    def validate_time_format(cls, v: str) -> str:
+        # HH:MM 형식 확인 (00:00 ~ 23:59)
+        if not re.match(r"^([01]\d|2[0-3]):([0-5]\d)$", v):
+            raise ValueError(f"시간 형식이 올바르지 않습니다. (HH:MM, 00:00~23:59): {v}")
+        return v
+
+    @field_validator('capacity')
+    @classmethod
+    def validate_capacity_range(cls, v: int) -> int:
+        if not (1 <= v <= 100):
+            raise ValueError("인원은 1명 이상 100명 이하여야 합니다.")
+        return v
+
+    @model_validator(mode='after')
+    def validate_logic(self) -> 'AvailabilityRequest':
+        # 1. Coordinate Range & Logic
+        # Latitude: -90 ~ 90
+        if not (-90 <= self.swLat <= 90) or not (-90 <= self.neLat <= 90):
+            raise ValueError("위도는 -90도에서 90도 사이여야 합니다.")
+            
+        # Longitude: -180 ~ 180
+        if not (-180 <= self.swLng <= 180) or not (-180 <= self.neLng <= 180):
+            raise ValueError("경도는 -180도에서 180도 사이여야 합니다.")
+
+        if self.swLat >= self.neLat:
+            raise ValueError("남서쪽 위도(swLat)는 북동쪽 위도(neLat)보다 작아야 합니다.")
+        if self.swLng >= self.neLng:
+            raise ValueError("남서쪽 경도(swLng)는 북동쪽 경도(neLng)보다 작아야 합니다.")
+            
+        # 2. Time Logic (Start < End & Past Time)
+        # NOTE: field_validator에서 정규식으로 형식을 보장하므로 strptime은 실패하지 않음
+        start = datetime.strptime(self.start_hour, "%H:%M")
+        end = datetime.strptime(self.end_hour, "%H:%M")
+        
+        if start >= end:
+            raise ValueError("시작 시간은 종료 시간보다 빨라야 합니다.")
+        
+        # 과거 시간 체크 (오늘인 경우)
+        input_date = datetime.strptime(self.date, "%Y-%m-%d").date()
+        if input_date == date.today():
+            now_time = datetime.now().time()
+            # 시작 시간이 현재 시간보다 이전이면 에러
+            if start.time() <= now_time:
+                raise ValueError("이미 지나간 시간은 예약할 수 없습니다.")
+                
+        return self
 
 
 # Policy Warning DTO

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -26,7 +26,6 @@ from app.models.dto import (
     AvailabilityRequest, AvailabilityResponse,
     RoomAvailability, BranchStats, PolicyWarning
 )
-from app.validate.request_validator import validate_availability_request, validate_map_coordinates
 from app.utils.room_router import filter_rooms_by_type
 from app.crawler.base import BaseCrawler
 from app.exception.base_exception import BaseCustomException, ErrorCode
@@ -35,6 +34,8 @@ from datetime import datetime, timedelta
 from app.utils.room_loader import get_rooms_by_criteria
 from fastapi import HTTPException
 from app.services.pricing_service import PricingService
+from app.validate.request_validator import validate_availability_request
+from app.validate.room_detail_validator import validate_room_detail_list
 
 logger = logging.getLogger("app")
 
@@ -107,8 +108,7 @@ class AvailabilityService:
             logger.error(f"Time slot generation error: {e}")
             raise HTTPException(status_code=400, detail=str(e))
         
-        # 1.5. 지도 좌표 유효성 검증 (필수)
-        validate_map_coordinates(request.swLat, request.swLng, request.neLat, request.neLng)
+        # 1.5. 지도 좌표 유효성 검증 (필수) -> DTO model_validator로 이관됨
 
         # 2. 인원수 및 지도 범위에 맞는 룸 필터링 (DB)
         target_rooms = get_rooms_by_criteria(
@@ -118,7 +118,7 @@ class AvailabilityService:
             neLat=request.neLat,
             neLng=request.neLng
         )
-
+        
         validate_availability_request(request.date, hour_slots, target_rooms)
 
         # 3. 크롤러 작업 준비 및 실행

--- a/app/validate/request_validator.py
+++ b/app/validate/request_validator.py
@@ -1,7 +1,7 @@
 from typing import List
-from fastapi import HTTPException
+
 from app.models.dto import RoomDetail
-from app.validate.date_validator import validate_date
+
 from app.validate.hour_validator import validate_hour_slots
 from app.validate.room_detail_validator import validate_room_detail_list
 
@@ -11,31 +11,19 @@ def validate_availability_request(
         target_rooms: List[RoomDetail],
 ):
     """
-    요청의 유효성을 검사합니다.
-    • 날짜 포맷 및 유효성 검증
-    • 시간 슬롯 포맷 및 과거/연속성 검증
-    • room detail 리스트 및 개별 room detail 검증
+    요청의 비즈니스 로직 유효성을 검사합니다.
+    (DTO에서 처리하지 못하는 복합 검증 수행)
+
+    1. 시간 슬롯 연속성 검증 (1시간 단위)
+    2. RoomDetail 리스트 검증
     """
-    validate_date(date)
+    # NOTE: 
+    # - 날짜/시간 포맷: AvailabilityRequest DTO에서 정규식으로 이미 검증됨
+    # - 좌표 유효성: AvailabilityRequest DTO에서 이미 검증됨
+    
+    # 시간 슬롯 연속성 검증 (13:00, 14:00, 15:00...)
+    # DTO는 개별 필드 검증에 집중하므로, 슬롯 간 관계 검증은 여기서 수행
     validate_hour_slots(hour_slots, date)
 
-    # RoomKey 관련 모든 검증을 한 번에 처리
+    # DB 조회 결과 검증
     validate_room_detail_list(target_rooms)
-
-def validate_map_coordinates(swLat: float, swLng: float, neLat: float, neLng: float):
-    """
-    지도 좌표의 유효성을 검증합니다.
-    """
-    # 1. 위도 경도 범위 체크
-    if not (-90 <= swLat <= 90) or not (-90 <= neLat <= 90):
-        raise HTTPException(status_code=400, detail="위도는 -90도에서 90도 사이여야 합니다.")
-    
-    if not (-180 <= swLng <= 180) or not (-180 <= neLng <= 180):
-        raise HTTPException(status_code=400, detail="경도는 -180도에서 180도 사이여야 합니다.")
-
-    # 2. 영역 논리 체크 (SW < NE)
-    if swLat >= neLat:
-        raise HTTPException(status_code=400, detail="남서쪽 위도(swLat)는 북동쪽 위도(neLat)보다 작아야 합니다.")
-
-    if swLng >= neLng:
-        raise HTTPException(status_code=400, detail="남서쪽 경도(swLng)는 북동쪽 경도(neLng)보다 작아야 합니다.")

--- a/tests/api/test_available_room_map.py
+++ b/tests/api/test_available_room_map.py
@@ -30,8 +30,12 @@ async def test_map_search_validation_error(async_client: AsyncClient, future_dat
     response = await async_client.get("/api/rooms/availability", params=params)
 
     # then
-    assert response.status_code == 400
-    assert "남서쪽 위도(swLat)는 북동쪽 위도(neLat)보다 작아야 합니다" in response.json()['message']
+    assert response.status_code == 422
+    data = response.json()
+    assert data['message'] == '입력값을 확인해주세요.'
+    # model_validator 에러는 result에 필드별로 들어감
+    result_str = str(data.get('result', {}))
+    assert "남서쪽 위도(swLat)는 북동쪽 위도(neLat)보다 작아야 합니다" in result_str
 
 
 @pytest.mark.asyncio
@@ -56,8 +60,11 @@ async def test_map_search_coordinate_range_error(async_client: AsyncClient, futu
     response = await async_client.get("/api/rooms/availability", params=params)
 
     # then
-    assert response.status_code == 400
-    assert "위도는 -90도에서 90도 사이여야 합니다" in response.json()['message']
+    assert response.status_code == 422
+    data = response.json()
+    assert data['message'] == '입력값을 확인해주세요.'
+    result_str = str(data.get('result', {}))
+    assert "위도는 -90도에서 90도 사이여야 합니다" in result_str
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_dto_validation.py
+++ b/tests/api/test_dto_validation.py
@@ -1,0 +1,80 @@
+from fastapi.testclient import TestClient
+from app.main import app
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+from app.core.limiter import limiter
+
+@pytest.fixture(autouse=True)
+def disable_limiter():
+    """Rate Limiter 비활성화 (검증 로직 테스트에서 429 방지)"""
+    limiter.enabled = False
+    yield
+    limiter.enabled = True
+
+client = TestClient(app)
+
+def test_availability_request_validation_error():
+    """AvailabilityRequest DTO 검증 실패 시 422 에러 반환 테스트"""
+    url = "/api/rooms/availability"
+    
+    # 1. Invalid Date Format (YYYY/MM/DD)
+    response = client.get(f"{url}?date=2024/01/01&capacity=3&start_hour=18:00&end_hour=21:00&swLat=37.0&swLng=127.0&neLat=38.0&neLng=128.0")
+    assert response.status_code == 422
+    assert "date" in response.text
+    
+    # 2. Invalid Time Format (HH-MM)
+    response = client.get(f"{url}?date=2024-01-01&capacity=3&start_hour=18-00&end_hour=21:00&swLat=37.0&swLng=127.0&neLat=38.0&neLng=128.0")
+    assert response.status_code == 422
+    assert "start_hour" in response.text
+
+    # 3. Invalid Time Range (25:00)
+    response = client.get(f"{url}?date=2024-01-01&capacity=3&start_hour=25:00&end_hour=21:00&swLat=37.0&swLng=127.0&neLat=38.0&neLng=128.0")
+    assert response.status_code == 422
+    assert "start_hour" in response.text
+
+    # 4. Invalid Capacity (0)
+    response = client.get(f"{url}?date=2024-01-01&capacity=0&start_hour=18:00&end_hour=21:00&swLat=37.0&swLng=127.0&neLat=38.0&neLng=128.0")
+    assert response.status_code == 422
+    assert "capacity" in response.text
+
+    # 5. Invalid Capacity (101 - Exceeds 100)
+    response = client.get(f"{url}?date=2024-01-01&capacity=101&start_hour=18:00&end_hour=21:00&swLat=37.0&swLng=127.0&neLat=38.0&neLng=128.0")
+    assert response.status_code == 422
+    assert "capacity" in response.text
+
+    # 6. Past Date (Logic Check)    
+    # Deterministic base time: Jan 1st, 2025 at 12:00 PM (Midday)
+    now = datetime(2025, 1, 1, 12, 0)
+    today_str = now.strftime("%Y-%m-%d")
+    
+    with patch('app.models.dto.date') as mock_date, \
+         patch('app.models.dto.datetime') as mock_datetime:
+        
+        mock_date.today.return_value = now.date()
+        mock_datetime.now.return_value = now
+        # datetime.strptime은 실제 함수를 사용하도록 설정
+        mock_datetime.strptime.side_effect = datetime.strptime
+        
+        # 6. Past Date
+        past_date = (now - timedelta(days=1)).strftime("%Y-%m-%d")
+        response = client.get(f"{url}?date={past_date}&capacity=3&start_hour=18:00&end_hour=21:00&swLat=37.0&swLng=127.0&neLat=38.0&neLng=128.0")
+        assert response.status_code == 422
+        assert "date" in response.text or "과거 날짜" in response.text
+
+        # 7. Start > End Time (Logic Check)
+        future_date = (now + timedelta(days=1)).strftime("%Y-%m-%d")
+        response = client.get(f"{url}?date={future_date}&capacity=3&start_hour=21:00&end_hour=18:00&swLat=37.0&swLng=127.0&neLat=38.0&neLng=128.0")
+        assert response.status_code == 422
+        assert "start_hour" in response.text or "end_hour" in response.text or "시작 시간" in response.text
+
+        # 9. Past Time (Today)
+        # 현재 시간(12:00)보다 1시간 전으로 요청 (11:00)
+        past_hour = (now - timedelta(hours=1)).strftime("%H:%M")
+        # end_hour는 14:00
+        end_hour = (now + timedelta(hours=2)).strftime("%H:%M")
+        
+        response = client.get(f"{url}?date={today_str}&capacity=3&start_hour={past_hour}&end_hour={end_hour}&swLat=37.0&swLng=127.0&neLat=38.0&neLng=128.0")
+        assert response.status_code == 422
+        assert "지나간 시간" in response.text or "past" in response.text.lower()

--- a/tests/api/test_favorites.py
+++ b/tests/api/test_favorites.py
@@ -105,21 +105,21 @@ def test_delete_favorite_idempotency(client, api_endpoint, headers, target_busin
     assert data["isSuccess"] is True
     assert data["result"] == {"deleted": True}
 
-@pytest.mark.parametrize("invalid_headers, expected_detail", [
-    ({}, "X-Device-Id header is required and cannot be empty"),                      # 헤더 누락
-    ({"X-Device-Id": ""}, "X-Device-Id header is required and cannot be empty"),     # 빈 헤더
-    ({"X-Device-Id": "   "}, "X-Device-Id header is required and cannot be empty"),  # 공백 헤더
-    ({"X-Device-Id": "not-a-uuid"}, "Invalid X-Device-Id format"), # 잘못된 형식
+@pytest.mark.parametrize("invalid_headers, expected_status, expected_detail", [
+    ({}, 422, None),                                                                  # 헤더 누락 → FastAPI 422
+    ({"X-Device-Id": ""}, 400, "X-Device-Id header is required and cannot be empty"),  # 빈 헤더
+    ({"X-Device-Id": "   "}, 400, "X-Device-Id header is required and cannot be empty"),  # 공백 헤더
+    ({"X-Device-Id": "not-a-uuid"}, 400, "Invalid X-Device-Id format"),                # 잘못된 형식
 ])
-def test_favorite_error_cases(client, api_endpoint, invalid_headers, expected_detail, target_business_id):
-    """잘못된 헤더 요청에 대해 적절한 400 에러를 반환해야 한다."""
+def test_favorite_error_cases(client, api_endpoint, invalid_headers, expected_status, expected_detail, target_business_id):
+    """잘못된 헤더 요청에 대해 적절한 에러를 반환해야 한다."""
     # Act
-    # business_id를 제공하여 422 Validation Error가 아닌 Header Check 로직까지 도달하도록 함
     response = client.put(api_endpoint, headers=invalid_headers, params={"business_id": target_business_id})
 
     # Assert
-    assert response.status_code == 400
-    assert response.json()["message"] == expected_detail
+    assert response.status_code == expected_status
+    if expected_detail:
+        assert response.json()["message"] == expected_detail
 
 
 # --------------------------------------------------------------------------
@@ -176,8 +176,7 @@ def test_get_favorites_isolation(client, headers, target_business_id):
     assert len(result["biz_item_ids"]) == 1
 
 def test_get_favorites_error_cases(client):
-    """GET 요청 시에도 잘못된 헤더에 대해 400 에러를 반환해야 한다."""
-    # 헤더 누락
+    """GET 요청 시에도 잘못된 헤더에 대해 에러를 반환해야 한다."""
+    # 헤더 누락 → Header(...)이므로 FastAPI가 422 반환
     response = client.get("/api/favorites", headers={})
-    assert response.status_code == 400
-    assert response.json()["message"] == "X-Device-Id header is required and cannot be empty"
+    assert response.status_code == 422

--- a/tests/exception/test_hour_validator.py
+++ b/tests/exception/test_hour_validator.py
@@ -34,7 +34,7 @@ def test_validate_hour_slots_past_time_today():
         # 여기서는 단순히 00:00 슬롯이 현재(00:xx)보다 과거임을 테스트합니다.
         slot = "00:00"
         if now.minute == 0:
-             pytest.skip("00:00 정각에는 과거 시간 테스트가 어려워 건너뜁니다.")
+            pytest.skip("00:00 정각에는 과거 시간 테스트가 어려워 건너뜁니다.")
     else:
         # 현재 시간보다 1시간 전
         slot = (now - timedelta(hours=1)).strftime("%H:%M")

--- a/tests/exception/test_hour_validator.py
+++ b/tests/exception/test_hour_validator.py
@@ -29,8 +29,16 @@ def test_validate_hour_slots_future_date():
 def test_validate_hour_slots_past_time_today():
     """오늘 날짜인데 과거 시간대를 포함하면 PastHourSlotNotAllowedError 예외가 발생해야 한다."""
     now = datetime.now()
-    # 현재 시간보다 1시간 전
-    slot = (now - timedelta(hours=1)).strftime("%H:%M")
+    if now.hour < 1:
+        # 새벽 1시 이전에는 1시간 전이 전날이 되므로 테스트를 위해 고정 시간을 사용하거나 건너뜁니다.
+        # 여기서는 단순히 00:00 슬롯이 현재(00:xx)보다 과거임을 테스트합니다.
+        slot = "00:00"
+        if now.minute == 0:
+             pytest.skip("00:00 정각에는 과거 시간 테스트가 어려워 건너뜁니다.")
+    else:
+        # 현재 시간보다 1시간 전
+        slot = (now - timedelta(hours=1)).strftime("%H:%M")
+        
     today = now.strftime("%Y-%m-%d")
     with pytest.raises(PastHourSlotNotAllowedError):
         validate_hour_slot_not_past(slot, today)

--- a/tests/services/test_availability_service.py
+++ b/tests/services/test_availability_service.py
@@ -49,12 +49,16 @@ class TestApplyPolicies:
 
     def test_sameday_reservation_warning(self, service):
         """당일 예약인데 requiresCallOnSameDay=True면 경고 발생"""
-        today = datetime.now().strftime("%Y-%m-%d")
-        req = AvailabilityRequest(
-            date=today, capacity=2, start_hour="23:00", end_hour="23:59",
+        # 테스트 시점에 따라 과거 시간 유효성 검사 실패가 발생하지 않도록 시간을 명시적으로 고정
+        now = datetime.now().replace(hour=12, minute=0, second=0, microsecond=0)
+        date = now.strftime("%Y-%m-%d")
+        
+        # model_construct를 통해 DTO의 과거 시간 밸리데이션(예: 12:00이 현재보다 과거인지)을 바이패스
+        req = AvailabilityRequest.model_construct(
+            date=date, capacity=2, start_hour="12:00", end_hour="13:00",
             swLat=37.0, swLng=126.0, neLat=38.0, neLng=127.0
         )
-        slots = ["14:00", "15:00"]
+        slots = ["12:00", "13:00"]
 
         room = RoomDetail(
             name="TestRoom", branch="Branch", business_id="b1", biz_item_id="r1",

--- a/tests/services/test_availability_service.py
+++ b/tests/services/test_availability_service.py
@@ -1,8 +1,12 @@
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
-from datetime import datetime
+from datetime import datetime, timedelta
 from app.services.availability_service import AvailabilityService
 from app.models.dto import AvailabilityRequest, RoomAvailability, RoomDetail
+
+
+# 미래 날짜를 사용하여 DTO 날짜 검증을 통과시킴
+FUTURE_DATE = (datetime.now() + timedelta(days=30)).strftime("%Y-%m-%d")
 
 
 @pytest.fixture
@@ -23,8 +27,8 @@ class TestApplyPolicies:
     def test_1hour_reservation_warning(self, service):
         """1시간 예약인데 canReserveOneHour=False면 경고 발생"""
         req = AvailabilityRequest(
-            date="2024-01-01", capacity=2, start_hour="14:00", end_hour="15:00",
-            swLat=0, swLng=0, neLat=0, neLng=0
+            date=FUTURE_DATE, capacity=2, start_hour="14:00", end_hour="15:00",
+            swLat=37.0, swLng=126.0, neLat=38.0, neLng=127.0
         )
         # NOTE: generate_time_slots("14:00", "15:00") → ["14:00", "15:00"] (end-inclusive)
         #        len(slots) - 1 == 1 → 1시간 예약으로 감지
@@ -47,8 +51,8 @@ class TestApplyPolicies:
         """당일 예약인데 requiresCallOnSameDay=True면 경고 발생"""
         today = datetime.now().strftime("%Y-%m-%d")
         req = AvailabilityRequest(
-            date=today, capacity=2, start_hour="14:00", end_hour="16:00",
-            swLat=0, swLng=0, neLat=0, neLng=0
+            date=today, capacity=2, start_hour="23:00", end_hour="23:59",
+            swLat=37.0, swLng=126.0, neLat=38.0, neLng=127.0
         )
         slots = ["14:00", "15:00"]
 
@@ -67,8 +71,8 @@ class TestApplyPolicies:
     def test_price_calculation_integration(self, service, mock_pricing_service):
         """PricingService가 호출되어 estimated_price가 설정되는지 검증"""
         req = AvailabilityRequest(
-            date="2024-01-01", capacity=4, start_hour="14:00", end_hour="16:00",
-            swLat=0, swLng=0, neLat=0, neLng=0
+            date=FUTURE_DATE, capacity=4, start_hour="14:00", end_hour="16:00",
+            swLat=37.0, swLng=126.0, neLat=38.0, neLng=127.0
         )
         slots = ["14:00", "15:00"]
 
@@ -90,8 +94,8 @@ class TestApplyPolicies:
     def test_price_calculation_error_handling(self, service, mock_pricing_service):
         """가격 계산 중 에러 발생 시 estimated_price는 None"""
         req = AvailabilityRequest(
-            date="2024-01-01", capacity=4, start_hour="14:00", end_hour="16:00",
-            swLat=0, swLng=0, neLat=0, neLng=0
+            date=FUTURE_DATE, capacity=4, start_hour="14:00", end_hour="16:00",
+            swLat=37.0, swLng=126.0, neLat=38.0, neLng=127.0
         )
         slots = ["14:00", "15:00"]
 
@@ -134,8 +138,8 @@ class TestCheckAvailabilityFlow:
         """DB 데이터가 없어도 Mock으로 전체 흐름 검증"""
         # Given
         req = AvailabilityRequest(
-            date="2026-02-14", capacity=3, start_hour="14:00", end_hour="16:00",
-            swLat=0, swLng=0, neLat=0, neLng=0
+            date=FUTURE_DATE, capacity=3, start_hour="14:00", end_hour="16:00",
+            swLat=37.0, swLng=126.0, neLat=38.0, neLng=127.0
         )
 
         mock_room = RoomDetail(
@@ -158,7 +162,6 @@ class TestCheckAvailabilityFlow:
 
         # When
         with patch("app.services.availability_service.get_rooms_by_criteria") as mock_db, \
-             patch("app.services.availability_service.validate_map_coordinates"), \
              patch("app.services.availability_service.filter_rooms_by_type", return_value=[mock_room]), \
              patch("app.services.availability_service.validate_availability_request"):
             mock_db.return_value = [mock_room]

--- a/tests/test_naver_map_crawler.py
+++ b/tests/test_naver_map_crawler.py
@@ -4,36 +4,60 @@ from unittest.mock import MagicMock, patch
 from app.crawler.naver_map_crawler import NaverMapCrawler
 
 def test_search_sync_integration():
-    """_search_sync 내부에서 헬퍼 메서드들이 호출되는지 통합 검증"""
+    """_search_sync 내부 동기 실행 흐름 검증 (Playwright & Dependencies Mock)"""
     crawler = NaverMapCrawler(headless=True)
     
-    with patch('app.crawler.naver_map_crawler.sync_playwright') as mock_pw, \
-         patch('app.crawler.naver_map_crawler.UserAgent') as mock_ua_class, \
-         patch('playwright_stealth.stealth_sync', create=True) as mock_stealth_sync:
-        
-        mock_ua_instance = MagicMock()
-        mock_ua_instance.random = "Test-UA"
-        mock_ua_class.return_value = mock_ua_instance
+    # playwright_stealth 모듈이 없을 경우를 대비해 sys.modules에 mock 추가
+    mock_stealth_module = MagicMock()
+    with patch.dict('sys.modules', {'playwright_stealth': mock_stealth_module}):
+        with patch('app.crawler.naver_map_crawler.sync_playwright') as mock_pw, \
+             patch('app.crawler.naver_map_crawler.UserAgent') as mock_ua_class:
+            
+            # 1. Setup Mock UserAgent
+            mock_ua_instance = MagicMock()
+            mock_ua_instance.random = "Test-UA"
+            mock_ua_class.return_value = mock_ua_instance
+            
+            # 2. Setup Mock Playwright
+            mock_p = MagicMock()
+            mock_browser = MagicMock()
+            mock_context = MagicMock()
+            mock_page = MagicMock()
+            
+            mock_pw.return_value.__enter__.return_value = mock_p
+            mock_p.chromium.launch.return_value = mock_browser
+            mock_browser.new_context.return_value = mock_context
+            mock_context.new_page.return_value = mock_page
+            
+            # 3. Setup Extract Apollo State Mock
+            with patch.object(crawler, '_extract_apollo_state_sync', return_value=[{"id": "123", "name": "Test Room"}]) as mock_extract:
+                
+                results = crawler._search_sync("test_query")
+                
+                # 검증
+                assert len(results) == 1
+                assert results[0]["id"] == "123"
+                
+                # UserAgent 호출 확인
+                mock_ua_class.assert_called()
+                
+                # Browser Context 생성 시 UA 전달 확인
+                call_args = mock_browser.new_context.call_args
+                assert call_args.kwargs['user_agent'] == "Test-UA"
+                
+                # Stealth 적용 확인 (mock_stealth_module.stealth_sync 호출 확인)
+                mock_stealth_module.stealth_sync.assert_called_once_with(mock_context)
+                
+                # Apollo State 추출 확인
+                mock_extract.assert_called()
 
-        mock_p = MagicMock()
-        mock_browser = MagicMock()
-        mock_context = MagicMock()
-        mock_page = MagicMock()
-        
-        mock_pw.return_value.__enter__.return_value = mock_p
-        mock_p.chromium.launch.return_value = mock_browser
-        mock_browser.new_context.return_value = mock_context
-        mock_context.new_page.return_value = mock_page
-        
-        # 내부 메서드 Mocking (실제 로직 실행 방지)
-        with patch.object(crawler, '_extract_apollo_state_sync', return_value=[]):
-            
-            crawler._search_sync("test_query")
-            
-            # 1. Context 생성 시 UA 전달 확인
-            call_args = mock_browser.new_context.call_args
-            assert call_args.kwargs['user_agent'] == "Test-UA"
-            
-            # 2. Stealth 로직 (Playwright) 호출 확인
-            assert mock_stealth_sync.call_count == 1
-            mock_stealth_sync.assert_called_with(mock_context)
+def test_extract_apollo_state_sync_mock():
+    """evaluate를 통한 Apollo State 추출 로직 검증 (Mock Page)"""
+    crawler = NaverMapCrawler()
+    mock_page = MagicMock()
+    mock_page.evaluate.return_value = [{"id": "999", "name": "Mocked Room"}]
+    
+    result = crawler._extract_apollo_state_sync(mock_page)
+    
+    assert result == [{"id": "999", "name": "Mocked Room"}]
+    mock_page.evaluate.assert_called_once()

--- a/tests/test_naver_map_crawler.py
+++ b/tests/test_naver_map_crawler.py
@@ -3,83 +3,18 @@ import sys
 from unittest.mock import MagicMock, patch
 from app.crawler.naver_map_crawler import NaverMapCrawler
 
-# Fixture to simulate missing dependencies
-@pytest.fixture
-def mock_missing_packages():
-    with patch('app.crawler.naver_map_crawler.UserAgent', None), \
-         patch('app.crawler.naver_map_crawler.Stealth', None), \
-        patch('app.crawler.naver_map_crawler.apply_stealth_sync', None):
-        yield
-
-# Fixture to simulate installed dependencies
-@pytest.fixture
-def mock_installed_packages():
-    mock_ua_class = MagicMock()
-    mock_ua_instance = MagicMock()
-    mock_ua_instance.random = "Mocked/UserAgent 1.0"
-    mock_ua_class.return_value = mock_ua_instance
-    
-    mock_stealth_class = MagicMock()
-    mock_stealth_instance = MagicMock()
-    mock_stealth_class.return_value = mock_stealth_instance
-    
-    mock_apply = MagicMock()
-    
-    with patch('app.crawler.naver_map_crawler.UserAgent', mock_ua_class), \
-         patch('app.crawler.naver_map_crawler.Stealth', mock_stealth_class), \
-         patch('app.crawler.naver_map_crawler.apply_stealth_sync', mock_apply):
-        yield mock_ua_instance, mock_apply
-
-def test_get_random_ua_installed(mock_installed_packages):
-    """fake-useragent 설치 시 랜덤 UA 반환 검증"""
-    _ = mock_installed_packages
-    crawler = NaverMapCrawler(headless=True)
-    ua = crawler._get_random_ua()
-    assert ua == "Mocked/UserAgent 1.0"
-
-def test_get_random_ua_generic_exception(mock_installed_packages):
-    """fake-useragent 사용 중 일반 예외(Exception) 발생 시 Fallback UA 반환 검증"""
-    mock_ua_instance, _ = mock_installed_packages
-    # random 접근 시 예외 발생 시뮬레이션
-    type(mock_ua_instance).random = property(lambda _self: (_ for _ in ()).throw(Exception("Random Error")))
-    
-    crawler = NaverMapCrawler(headless=True)
-    ua = crawler._get_random_ua()
-    assert "Mozilla/5.0" in ua
-    assert "Mocked" not in ua
-
-def test_get_random_ua_missing(mock_missing_packages):
-    """fake-useragent 미설치 시 Fallback UA 반환 검증"""
-    _ = mock_missing_packages
-    crawler = NaverMapCrawler(headless=True)
-    ua = crawler._get_random_ua()
-    assert "Mozilla/5.0" in ua
-    assert "Mocked" not in ua
-
-def test_apply_stealth_installed(mock_installed_packages):
-    """playwright-stealth 설치 시 stealth() 호출 검증"""
-    _, mock_apply = mock_installed_packages
-    crawler = NaverMapCrawler(headless=True)
-    mock_page = MagicMock()
-    
-    crawler._apply_stealth(mock_page)
-    
-    mock_apply.assert_called_once_with(mock_page)
-
-def test_apply_stealth_missing(mock_missing_packages):
-    """playwright-stealth 미설치 시 에러 없이 로그만 남기는지 검증"""
-    _ = mock_missing_packages
-    crawler = NaverMapCrawler(headless=True)
-    mock_page = MagicMock()
-    
-    # 예외가 발생하지 않아야 함
-    crawler._apply_stealth(mock_page)
-
 def test_search_sync_integration():
     """_search_sync 내부에서 헬퍼 메서드들이 호출되는지 통합 검증"""
     crawler = NaverMapCrawler(headless=True)
     
-    with patch('app.crawler.naver_map_crawler.sync_playwright') as mock_pw:
+    with patch('app.crawler.naver_map_crawler.sync_playwright') as mock_pw, \
+         patch('app.crawler.naver_map_crawler.UserAgent') as mock_ua_class, \
+         patch('playwright_stealth.stealth_sync', create=True) as mock_stealth_sync:
+        
+        mock_ua_instance = MagicMock()
+        mock_ua_instance.random = "Test-UA"
+        mock_ua_class.return_value = mock_ua_instance
+
         mock_p = MagicMock()
         mock_browser = MagicMock()
         mock_context = MagicMock()
@@ -91,18 +26,14 @@ def test_search_sync_integration():
         mock_context.new_page.return_value = mock_page
         
         # 내부 메서드 Mocking (실제 로직 실행 방지)
-        with patch.object(crawler, '_get_random_ua', return_value="Test-UA") as mock_get_ua, \
-             patch.object(crawler, '_apply_stealth') as mock_apply_stealth, \
-             patch.object(crawler, '_extract_apollo_state_sync', return_value=[]):
+        with patch.object(crawler, '_extract_apollo_state_sync', return_value=[]):
             
             crawler._search_sync("test_query")
             
-            # 1. UA 생성 호출 확인
-            mock_get_ua.assert_called_once()
-            
-            # 2. Context 생성 시 UA 전달 확인
+            # 1. Context 생성 시 UA 전달 확인
             call_args = mock_browser.new_context.call_args
             assert call_args.kwargs['user_agent'] == "Test-UA"
             
-            # 3. Stealth 적용 호출 확인
-            mock_apply_stealth.assert_called_once_with(mock_page)
+            # 2. Stealth 로직 (Playwright) 호출 확인
+            assert mock_stealth_sync.call_count == 1
+            mock_stealth_sync.assert_called_with(mock_context)

--- a/tests/unit/test_coordinate_logic.py
+++ b/tests/unit/test_coordinate_logic.py
@@ -1,0 +1,54 @@
+from app.models.dto import AvailabilityRequest
+from pydantic import ValidationError
+import pytest
+
+def test_coordinate_range_invalid_lat():
+    """위도 범위(-90~90) 초과 테스트"""
+    data = {
+        "date": "2029-12-31",
+        "capacity": 3,
+        "start_hour": "14:00",
+        "end_hour": "16:00",
+        "swLat": -91.0, "swLng": 127.0, "neLat": 38.0, "neLng": 128.0
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        AvailabilityRequest(**data)
+    assert "위도" in str(excinfo.value)
+
+def test_coordinate_range_invalid_lng():
+    """경도 범위(-180~180) 초과 테스트"""
+    data = {
+        "date": "2029-12-31",
+        "capacity": 3,
+        "start_hour": "14:00",
+        "end_hour": "16:00",
+        "swLat": 37.0, "swLng": -181.0, "neLat": 38.0, "neLng": 128.0
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        AvailabilityRequest(**data)
+    assert "경도" in str(excinfo.value)
+
+def test_coordinate_order_invalid():
+    """좌표 정렬(SW < NE) 실패 테스트"""
+    data = {
+        "date": "2029-12-31",
+        "capacity": 3,
+        "start_hour": "14:00",
+        "end_hour": "16:00",
+        "swLat": 38.0, "swLng": 127.0, "neLat": 37.0, "neLng": 128.0
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        AvailabilityRequest(**data)
+    assert "작아야 합니다" in str(excinfo.value)
+
+def test_coordinate_success():
+    """정상 좌표 통과 테스트"""
+    data = {
+        "date": "2029-12-31",
+        "capacity": 3,
+        "start_hour": "14:00",
+        "end_hour": "16:00",
+        "swLat": 37.0, "swLng": 127.0, "neLat": 37.5, "neLng": 127.5
+    }
+    req = AvailabilityRequest(**data)
+    assert req.swLat == 37.0

--- a/tests/unit/test_date_logic.py
+++ b/tests/unit/test_date_logic.py
@@ -1,0 +1,54 @@
+from app.models.dto import AvailabilityRequest
+from pydantic import ValidationError
+import pytest
+from datetime import datetime, date
+
+def test_date_calendar_validity():
+    """달력상 유효하지 않은 날짜(예: 2월 30일) 검증 테스트"""
+    data = {
+        "date": "2024-02-30",
+        "capacity": 3,
+        "start_hour": "14:00",
+        "end_hour": "16:00",
+        "swLat": 37.0, "swLng": 127.0, "neLat": 38.0, "neLng": 128.0
+    }
+    
+    with pytest.raises(ValidationError) as excinfo:
+        AvailabilityRequest(**data)
+    
+    # 에러 메시지에 "날짜 형식" 또는 "올바르지 않습니다" 포함 확인
+    assert "날짜 형식" in str(excinfo.value)
+
+def test_date_past_validity():
+    """과거 날짜 검증 테스트"""
+    data = {
+        "date": "2020-01-01",
+        "capacity": 3,
+        "start_hour": "14:00",
+        "end_hour": "16:00",
+        "swLat": 37.0, "swLng": 127.0, "neLat": 38.0, "neLng": 128.0
+    }
+    
+    with pytest.raises(ValidationError) as excinfo:
+        AvailabilityRequest(**data)
+    
+    assert "과거 날짜" in str(excinfo.value)
+
+def test_date_success():
+    """정상 날짜 통과 테스트"""
+    # 미래의 날짜 사용
+    future_date = "2029-12-31"
+    data = {
+        "date": future_date,
+        "capacity": 3,
+        "start_hour": "14:00",
+        "end_hour": "16:00",
+        "swLat": 37.0, "swLng": 127.0, "neLat": 38.0, "neLng": 128.0
+    }
+    
+    req = AvailabilityRequest(**data)
+    assert req.date == future_date
+
+if __name__ == "__main__":
+    # 직접 실행 시 pytest로 실행
+    pytest.main([__file__])


### PR DESCRIPTION
## 영향 범위
- 서버 테스트 코드 전반 (Naver Map Crawler 통합 테스트)
- [tests/test_naver_map_crawler.py]

## 구현 내용
### AS-IS
- [NaverMapCrawler] 리팩토링 과정에서 관심사 분리로 작성되었던 `_get_random_ua`와 `_apply_stealth` 헬퍼 메서드가 최신 Playwright Stealth 방식(Context 단위 적용)에 맞춰 [_search_sync] 내부 로직으로 통합(인라인화) 되었습니다.
- 하지만 테스트 코드에는 여전히 삭제된 레거시 메서드들을 단독으로 검증하고 패치하는 단위 테스트들이 남아 있어, CI/CD 환경 및 로컬 테스트 실행 시 존재하지 않는 함수를 호출하려다 `AttributeError`가 발생하고 통합 테스트가 실패하고 있었습니다.

### TO-BE
- [x] 더 이상 존재하지 않는 레거시 메서드(`_get_random_ua`, `_apply_stealth`)를 단독으로 검증하던 무의미한 단위 테스트 및 관련 픽스처 전면 삭제
- [x] 통합 테스트([test_search_sync_integration]에서 삭제된 `_get_random_ua`에 대한 Mocking 어노테이션 제거
- [x] 통합 테스트 코드 내에서 `Stealth` 컨텍스트 로직이 실제로 호출되는지 검증하기 위해 `playwright_stealth.stealth_sync`를 직접 올바르게 패치하도록 구조 수정

## 특이사항
- 해당 변경으로 인해 로컬에서 에러를 뿜으며 실패하던 크롤러 단위 테스트 및 통합 테스트가 문법 에러와 의존성 에러 없이 모두 정상 통과(Pass)하는 것을 확인했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API now requires a non-empty X-Device-Id header (must be a valid UUID) and returns clear validation errors.
* **Bug Fixes**
  * Stronger request validation for dates, times, capacities, and geographic bounds with standardized 422 responses and clearer field-level messages.
* **Tests**
  * Expanded validation test suite covering DTO/date/time/capacity/coordinate scenarios and updated error-expectation assertions for consistent responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->