### PR TITLE
hotfix: fix dev CI failures after PR #162 merge

### DIFF
--- a/app/models/dto.py
+++ b/app/models/dto.py
@@ -153,20 +153,27 @@ class AvailabilityRequest(BaseModel):
     def validate_date_regex(cls, value: str) -> str:
         """YYYY-MM-DD 형식 + 실제 달력 유효 날짜를 검증"""
         if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
-            raise ValueError("date must match YYYY-MM-DD")
+            raise ValueError("날짜 형식이 올바르지 않습니다. (YYYY-MM-DD)")
         try:
             input_date = datetime.strptime(value, "%Y-%m-%d").date()
         except ValueError as exc:
-            raise ValueError("date must be a valid YYYY-MM-DD calendar date") from exc
+            raise ValueError("날짜 형식이 올바르지 않습니다. (YYYY-MM-DD)") from exc
         if input_date < date.today():
-            raise ValueError("past dates are not allowed")
+            raise ValueError("과거 날짜는 예약할 수 없습니다.")
         return value
 
-    @field_validator("start_hour", "end_hour")
+    @field_validator("start_hour")
     @classmethod
-    def validate_time_format(cls, value: str) -> str:
+    def validate_start_time_format(cls, value: str) -> str:
         if not re.fullmatch(r"^([01]\d|2[0-3]):([0-5]\d)$", value):
-            raise ValueError("time must match HH:MM (00:00~23:59)")
+            raise ValueError("시간 형식이 올바르지 않습니다. (HH:MM, 00:00~23:59)")
+        return value
+
+    @field_validator("end_hour")
+    @classmethod
+    def validate_end_time_format(cls, value: str) -> str:
+        if not re.fullmatch(r"^(([01]\d|2[0-3]):([0-5]\d)|24:00)$", value):
+            raise ValueError("종료 시간 형식이 올바르지 않습니다. (HH:MM, 00:00~24:00)")
         return value
 
     @field_validator("capacity")
@@ -174,28 +181,31 @@ class AvailabilityRequest(BaseModel):
     def validate_capacity_range(cls, value: int) -> int:
         """합주실 요청 인원수는 1~50 범위만 허용"""
         if not 1 <= value <= 50:
-            raise ValueError("capacity must be between 1 and 50")
+            raise ValueError("인원은 1명 이상 50명 이하여야 합니다.")
         return value
 
     @model_validator(mode="after")
     def validate_logic(self) -> "AvailabilityRequest":
         if not (-90 <= self.swLat <= 90) or not (-90 <= self.neLat <= 90):
-            raise ValueError("latitude must be between -90 and 90")
+            raise ValueError("위도는 -90도에서 90도 사이여야 합니다.")
         if not (-180 <= self.swLng <= 180) or not (-180 <= self.neLng <= 180):
-            raise ValueError("longitude must be between -180 and 180")
+            raise ValueError("경도는 -180도에서 180도 사이여야 합니다.")
         if self.swLat >= self.neLat:
-            raise ValueError("swLat must be less than neLat")
+            raise ValueError("남서쪽 위도(swLat)는 북동쪽 위도(neLat)보다 작아야 합니다.")
         if self.swLng >= self.neLng:
-            raise ValueError("swLng must be less than neLng")
+            raise ValueError("남서쪽 경도(swLng)는 북동쪽 경도(neLng)보다 작아야 합니다.")
 
-        start = datetime.strptime(self.start_hour, "%H:%M")
-        end = datetime.strptime(self.end_hour, "%H:%M")
-        if start >= end:
-            raise ValueError("start_hour must be earlier than end_hour")
+        start_minutes = int(self.start_hour[:2]) * 60 + int(self.start_hour[3:])
+        end_minutes = 1440 if self.end_hour == "24:00" else int(self.end_hour[:2]) * 60 + int(self.end_hour[3:])
+        if start_minutes >= end_minutes:
+            raise ValueError("시작 시간은 종료 시간보다 빨라야 합니다.")
 
         input_date = datetime.strptime(self.date, "%Y-%m-%d").date()
-        if input_date == date.today() and start.time() <= datetime.now().time():
-            raise ValueError("past time is not allowed for today")
+        if input_date == date.today():
+            now_time = datetime.now()
+            now_minutes = now_time.hour * 60 + now_time.minute
+            if start_minutes <= now_minutes:
+                raise ValueError("이미 지나간 시간은 예약할 수 없습니다.")
 
         return self
 

--- a/app/services/room_parser_service.py
+++ b/app/services/room_parser_service.py
@@ -318,6 +318,54 @@ class RoomParserService:
         if not rec_range and rec_cap:
             rec_range = [rec_cap, rec_cap]  # 단일값은 [n, n]으로 디폴트
 
+        def _map_day_type(keyword: Optional[str]) -> str:
+            if keyword == "평일":
+                return "weekday"
+            if keyword in {"주말", "공휴일"}:
+                return "weekend"
+            return day_type or "weekday"
+
+        price_config = None
+
+        time_override_match = re.search(
+            r"(평일|주말|공휴일)?\s*(\d{1,2})시\s*이후\s*(\d+(?:,\d+)?)\s*원",
+            desc,
+        )
+        if time_override_match:
+            override_day = _map_day_type(time_override_match.group(1))
+            start_hour_num = int(time_override_match.group(2))
+            override_price = int(time_override_match.group(3).replace(",", ""))
+            if 0 <= start_hour_num <= 23:
+                price_config = {
+                    "default": None,
+                    "overrides": [
+                        {
+                            "day_type": override_day,
+                            "start_hour": f"{start_hour_num:02d}:00",
+                            "end_hour": "24:00",
+                            "price": override_price,
+                        }
+                    ],
+                    "surcharges": [],
+                }
+
+        surcharge_match = re.search(
+            r"(평일|주말|공휴일)?\s*(\d+(?:,\d+)?)\s*원\s*추가",
+            desc,
+        )
+        if surcharge_match:
+            surcharge_day = _map_day_type(surcharge_match.group(1))
+            surcharge_amount = int(surcharge_match.group(2).replace(",", ""))
+            if price_config is None:
+                price_config = {
+                    "default": None,
+                    "overrides": [],
+                    "surcharges": [],
+                }
+            price_config["surcharges"].append(
+                {"day_type": surcharge_day, "amount": surcharge_amount}
+            )
+
         return {
             "clean_name": clean_name,
             "day_type": day_type,
@@ -326,6 +374,7 @@ class RoomParserService:
             "recommend_capacity_range": rec_range,
             "base_capacity": base_cap,
             "extra_charge": extra_charge,
+            "price_config": price_config,
             "requires_call_on_same_day": requires_call
         }
 

--- a/app/utils/room_loader.py
+++ b/app/utils/room_loader.py
@@ -1,46 +1,62 @@
-from app.core.supabase_client import supabase
 from typing import List, Optional
-from app.exception.api.room_loader_exception import RoomLoaderFailedError
-from app.models.dto import RoomDetail
+
 from postgrest.exceptions import APIError
 from pydantic import ValidationError
 
-# NOTE: API 레벨에서는 좌표가 필수(Mandatory)이지만, 기존 유닛 테스트 코드들과의 
-# 하위 호환성을 위해 내부 유틸리티 함수에서는 Optional로 유지합니다. 
-# 추후 모든 테스트 코드에 Dummy 좌표를 적용한 뒤 필수값으로 리팩토링 예정입니다.
+from app.core.supabase_client import supabase
+from app.exception.api.room_loader_exception import RoomLoaderFailedError
+from app.models.dto import RoomDetail
+
+
 def get_rooms_by_criteria(
     capacity: int,
     swLat: Optional[float] = None,
     swLng: Optional[float] = None,
     neLat: Optional[float] = None,
-    neLng: Optional[float] = None
+    neLng: Optional[float] = None,
 ) -> List[RoomDetail]:
-
     """
-    Supabase에서 capacity 이상인 룸만 조회합니다.
+    Supabase에서 capacity 이상인 룸을 조회합니다.
     좌표가 주어지면 해당 범위 내의 룸만 필터링합니다.
     """
     try:
-        # 기본 쿼리: 인원수 조건 & Branch 정보 Join
-        # v2.0.0: price_config, min_capacity 관련 필드 및 branch 전화번호, rule 등 추가 조회
-        # NOTE: branch 테이블의 컬럼들이 마이그레이션 되어 있어야 함
-        query = supabase.table("room").select(
-            # left join으로 branch 정보가 누락된 room도 조회되게 유지
-            "*, branch(name, lat, lng, phone_number, display_name, open_wait_rule)"
-        ).gte("max_capacity", capacity)
+        # Deploy 환경마다 branch 컬럼 반영 시점이 다를 수 있어 select를 순차 fallback.
+        select_candidates = [
+            "*, branch(name, lat, lng, phone_number, display_name, open_wait_rule)",
+            "*, branch(name, lat, lng, phone_number, display_name)",
+            "*, branch(name, lat, lng)",
+        ]
 
-        response = query.execute()
+        response = None
+        last_error: Optional[Exception] = None
+        for select_expr in select_candidates:
+            try:
+                response = (
+                    supabase.table("room")
+                    .select(select_expr)
+                    .gte("max_capacity", capacity)
+                    .execute()
+                )
+                break
+            except APIError as e:
+                last_error = e
+                # undefined_column(42703)만 fallback, 나머지 API 에러는 즉시 중단.
+                if "42703" not in str(e):
+                    raise
+                continue
 
-        target_rooms = []
+        if response is None:
+            raise last_error if last_error else RoomLoaderFailedError("데이터베이스 쿼리 실패")
+
+        target_rooms: List[RoomDetail] = []
         for row in response.data:
-            # Data Flattening: branch 객체 내의 정보를 상위로 추출
-            if "branch" in row and isinstance(row["branch"], dict):
-                row["lat"] = row["branch"].get("lat")
-                row["lng"] = row["branch"].get("lng")
-                # v2.0.0 Branch Info
-                row["phone_number"] = row["branch"].get("phone_number")
-                row["display_name"] = row["branch"].get("display_name")
-                row["open_wait_rule"] = row["branch"].get("open_wait_rule")
+            branch = row.get("branch")
+            if isinstance(branch, dict):
+                row["lat"] = branch.get("lat")
+                row["lng"] = branch.get("lng")
+                row["phone_number"] = branch.get("phone_number")
+                row["display_name"] = branch.get("display_name")
+                row["open_wait_rule"] = branch.get("open_wait_rule")
             else:
                 row["branch"] = RoomDetail.BRANCH_FALLBACK_NAME
                 row["lat"] = None
@@ -49,20 +65,19 @@ def get_rooms_by_criteria(
                 row["display_name"] = None
                 row["open_wait_rule"] = {}
 
-            # 좌표 필터는 branch 좌표가 존재할 때만 적용.
-            # branch 누락 room은 fallback 목적상 결과에서 제외하지 않음.
+            # branch 좌표가 있는 경우에만 지도 경계 필터 적용.
             if all(v is not None for v in [swLat, swLng, neLat, neLng]):
                 lat = row.get("lat")
                 lng = row.get("lng")
                 if lat is not None and lng is not None:
                     if not (swLat <= lat <= neLat and swLng <= lng <= neLng):
                         continue
-            
-            # image_urls가 None인 경우 빈 리스트로 변환 (DTO 요구사항 준수)
+
             if row.get("image_urls") is None:
                 row["image_urls"] = []
-                
+
             target_rooms.append(RoomDetail.model_validate(row))
+
         return target_rooms
 
     except APIError as e:

--- a/tests/api/test_available_room.py
+++ b/tests/api/test_available_room.py
@@ -6,8 +6,15 @@ from app.main import app
 from app.crawler.base import BaseCrawler, RoomResult
 from app.models.dto import RoomAvailability, RoomDetail
 from app.api.dependencies import get_crawlers_map
+from app.core.limiter import limiter
 
 client = TestClient(app)
+
+@pytest.fixture(autouse=True)
+def disable_limiter():
+    limiter.enabled = False
+    yield
+    limiter.enabled = True
 
 
 # --- Mock Crawler Definition ---

--- a/tests/exception/test_room_detail_validator.py
+++ b/tests/exception/test_room_detail_validator.py
@@ -1,54 +1,59 @@
 import pytest
+
+from app.exception.common.room_detail_exception import (
+    RoomDetailFieldMissingError,
+    RoomDetailListEmptyError,
+)
+from app.models.dto import RoomDetail
 from app.validate.room_detail_validator import (
     validate_list_not_empty,
     validate_room_detail_fields,
-    validate_room_detail_list
 )
-from app.exception.common.room_detail_exception import RoomDetailFieldMissingError, RoomDetailListEmptyError
-from app.models.dto import RoomDetail
 
 
-# --- 단위 테스트: validate_list_not_empty ---
+def _room(**overrides) -> RoomDetail:
+    payload = {
+        "business_id": "522011",
+        "biz_item_id": "3968885",
+        "name": "블랙룸",
+        "branch": "비상합주실 1호점",
+        "imageUrls": [],
+        "maxCapacity": 0,
+        "recommendCapacity": 0,
+        "pricePerHour": 0,
+        "canReserveOneHour": False,
+        "requiresCallOnSameDay": False,
+    }
+    payload.update(overrides)
+    return RoomDetail(**payload)
+
 
 def test_validate_list_empty():
-    """빈 리스트가 주어졌을 때 RoomDetailListEmptyError 예외가 발생해야 한다."""
     with pytest.raises(RoomDetailListEmptyError):
         validate_list_not_empty([])
 
 
 def test_validate_list_not_empty_success():
-    """요소가 있는 리스트는 예외 없이 통과해야 한다."""
-    try:
-        validate_list_not_empty([RoomDetail(name="A", branch="B", business_id="1", biz_item_id="2", imageUrls=[], maxCapacity=0, recommendCapacity=0, pricePerHour=0, canReserveOneHour=False, requiresCallOnSameDay=False)])
-    except RoomDetailListEmptyError:
-        pytest.fail("RoomDetailListEmptyError가 예기치 않게 발생했습니다.")
+    validate_list_not_empty([_room()])
 
-
-# --- 단위 테스트: validate_room_detail_fields ---
 
 @pytest.mark.parametrize(
     "invalid_room",
     [
-        # business_id가 빈 문자열인 경우
-        RoomDetail(business_id="", biz_item_id="3968885", name="블랙룸", branch="비쥬합주실 1호점", imageUrls=[], maxCapacity=0, recommendCapacity=0, pricePerHour=0, canReserveOneHour=False, requiresCallOnSameDay=False),
-        # biz_item_id가 빈 문자열인 경우
-        RoomDetail(business_id="522011", biz_item_id="", name="블랙룸", branch="비쥬합주실 1호점", imageUrls=[], maxCapacity=0, recommendCapacity=0, pricePerHour=0, canReserveOneHour=False, requiresCallOnSameDay=False),
-        # name이 빈 문자열인 경우
-        RoomDetail(business_id="522011", biz_item_id="3968885", name="", branch="비쥬합주실 1호점", imageUrls=[], maxCapacity=0, recommendCapacity=0, pricePerHour=0, canReserveOneHour=False, requiresCallOnSameDay=False),
-        # branch가 빈 문자열인 경우
-        RoomDetail(business_id="522011", biz_item_id="3968885", name="블랙룸", branch="", imageUrls=[], maxCapacity=0, recommendCapacity=0, pricePerHour=0, canReserveOneHour=False, requiresCallOnSameDay=False),
-    ]
+        _room(business_id=""),
+        _room(biz_item_id=""),
+        _room(name=""),
+    ],
 )
 def test_validate_room_detail_field_missing(invalid_room: RoomDetail):
-    """RoomDetail의 필수 필드가 하나라도 누락된 경우 RoomDetailFieldMissingError 예외가 발생해야 한다."""
     with pytest.raises(RoomDetailFieldMissingError):
         validate_room_detail_fields(invalid_room)
 
 
+def test_validate_room_detail_fields_allows_empty_branch_with_fallback():
+    # branch가 비어도 RoomDetail validator가 fallback branch를 채운다.
+    validate_room_detail_fields(_room(branch=""))
+
+
 def test_validate_room_detail_fields_success():
-    """모든 필드가 유효한 RoomDetail은 예외 없이 통과해야 한다."""
-    valid_room = RoomDetail(business_id="522011", biz_item_id="3968885", name="블랙룸", branch="비쥬합주실 1호점", imageUrls=[], maxCapacity=0, recommendCapacity=0, pricePerHour=0, canReserveOneHour=False, requiresCallOnSameDay=False)
-    try:
-        validate_room_detail_fields(valid_room)
-    except RoomDetailFieldMissingError:
-        pytest.fail("RoomDetailFieldMissingError가 예기치 않게 발생했습니다.")
+    validate_room_detail_fields(_room())

--- a/tests/services/test_availability_service.py
+++ b/tests/services/test_availability_service.py
@@ -120,8 +120,8 @@ class TestApplyPolicies:
     def test_price_calculation_list_config_supports_24h_end(self, service, mock_pricing_service):
         """list price_config 경로에서 24:00 종료 시각을 다음날 00:00으로 변환"""
         req = AvailabilityRequest(
-            date="2024-01-01", capacity=4, start_hour="22:00", end_hour="24:00",
-            swLat=0, swLng=0, neLat=0, neLng=0
+            date="2099-01-01", capacity=4, start_hour="22:00", end_hour="24:00",
+            swLat=0.0, swLng=0.0, neLat=1.0, neLng=1.0
         )
         slots = ["22:00", "23:00", "24:00"]
 
@@ -138,8 +138,8 @@ class TestApplyPolicies:
         results = service._apply_policies([avail], req, slots)
 
         kwargs = mock_pricing_service.calculate_total_price.call_args.kwargs
-        assert kwargs["start_dt"] == datetime(2024, 1, 1, 22, 0)
-        assert kwargs["end_dt"] == datetime(2024, 1, 2, 0, 0)
+        assert kwargs["start_dt"] == datetime(2099, 1, 1, 22, 0)
+        assert kwargs["end_dt"] == datetime(2099, 1, 2, 0, 0)
         assert results[0].estimated_price == 20000
 
 


### PR DESCRIPTION
## Summary
- Restore Korean validation error messages in AvailabilityRequest and allow end_hour=24:00
- Add fallback room query projection when ranch.open_wait_rule column is missing
- Add regex-based price_config extraction in room parser fallback
- Stabilize API test by disabling rate limiter in 	ests/api/test_available_room.py
- Align room detail validator test with branch fallback behavior
- Update 24:00 pricing test fixture values to valid coordinates/future date

## Verification
- python -m pytest tests -q
  - result: 234 passed, 2 skipped
- (local note) running plain pytest at repo root can collect local 	est_*.txt artifacts; CI command runs against source tests only

## Incident context
This hotfix addresses the deploy-blocking test failures observed on dev immediately after merging PR #162.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for time-based pricing configurations, including hourly rate overrides and surcharges based on day type.

* **Bug Fixes**
  * Localized and clarified validation error messages for improved user experience.
  * Enhanced room data retrieval with improved error handling and robust fallback mechanisms for better reliability.

* **Tests**
  * Improved test infrastructure with enhanced fixtures and validation helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->