### PR TITLE
[#181]; refactor: 즐겨찾기 상한 개수(20개) 제한

### DIFF
--- a/app/api/favorites.py
+++ b/app/api/favorites.py
@@ -30,6 +30,10 @@ def add_favorite(
     Returns:
         ApiResponse[Dict]: 성공 여부
     """
+    # 이미 등록된 즐겨찾기면 에러(또는 개수 체크) 없이 성공 반환 (멱등성 보장)
+    if repo.exists(device_id=x_device_id, business_id=business_id, biz_item_id=biz_item_id):
+        return ApiResponse.success(result={"added": True})
+        
     # 갯수 제한 체크
     if repo.count_by_device(device_id=x_device_id) >= MAX_FAVORITES_PER_DEVICE:
         raise FavoriteLimitExceededError()

--- a/app/api/favorites.py
+++ b/app/api/favorites.py
@@ -3,6 +3,9 @@ from typing import Dict, Any, List
 from app.repositories.base import IFavoriteRepository
 from app.api.dependencies import get_favorite_repository, validate_device_id
 from app.core.response import ApiResponse
+from app.exception.api.favorite_exception import FavoriteLimitExceededError
+
+MAX_FAVORITES_PER_DEVICE = 20
 
 router = APIRouter(
     prefix="/api/favorites",
@@ -27,6 +30,10 @@ def add_favorite(
     Returns:
         ApiResponse[Dict]: 성공 여부
     """
+    # 갯수 제한 체크
+    if repo.count_by_device(device_id=x_device_id) >= MAX_FAVORITES_PER_DEVICE:
+        raise FavoriteLimitExceededError()
+        
     repo.add(device_id=x_device_id, business_id=business_id, biz_item_id=biz_item_id)
     
     return ApiResponse.success(result={"added": True})

--- a/app/exception/api/favorite_exception.py
+++ b/app/exception/api/favorite_exception.py
@@ -1,0 +1,9 @@
+from app.exception.base_exception import BaseCustomException, ErrorCode
+
+class FavoriteLimitExceededError(BaseCustomException):
+    def __init__(self, message: str = "즐겨찾기 추가 상한에 도달했습니다."):
+        super().__init__(
+            status_code=400,
+            error_code=ErrorCode.COMMON_BAD_REQUEST,
+            message=message
+        )

--- a/app/repositories/base.py
+++ b/app/repositories/base.py
@@ -41,6 +41,18 @@ class IFavoriteRepository(Protocol):
             bool: 존재하면 True, 없으면 False
         """
         ...
+        
+    def count_by_device(self, device_id: str) -> int:
+        """
+        사용자의 즐겨찾기 개수 조회
+        
+        Args:
+            device_id (str): 사용자(기기) 식별 ID
+            
+        Returns:
+            int: 즐겨찾기 개수
+        """
+        ...
     
     def get_all(self, device_id: str) -> List[str]:
         """

--- a/app/repositories/memory.py
+++ b/app/repositories/memory.py
@@ -28,5 +28,8 @@ class MockFavoriteRepository(IFavoriteRepository):
     def exists(self, device_id: str, business_id: str, biz_item_id: str) -> bool:
         return (device_id, business_id, biz_item_id) in self._data
 
+    def count_by_device(self, device_id: str) -> int:
+        return sum(1 for dev_id, _, _ in self._data if dev_id == device_id)
+
     def get_all(self, device_id: str) -> List[str]:
         return [biz_id for dev_id, _, biz_id in self._data if dev_id == device_id]

--- a/app/repositories/supabase_repository.py
+++ b/app/repositories/supabase_repository.py
@@ -84,7 +84,7 @@ class SupabaseFavoriteRepository(IFavoriteRepository):
             return response.count or 0
         except Exception as e:
             logger.error(f"Error fetching favorite count: {e}")
-            return 0
+            raise
 
     def get_all(self, device_id: str) -> List[str]:
         """

--- a/app/repositories/supabase_repository.py
+++ b/app/repositories/supabase_repository.py
@@ -72,6 +72,20 @@ class SupabaseFavoriteRepository(IFavoriteRepository):
             logger.error(f"Error checking existence: {e}")
             return False
 
+    def count_by_device(self, device_id: str) -> int:
+        """
+        Retrieves the total number of favorite items for a device.
+        """
+        try:
+            response = self.supabase.table(self.table_name).select(
+                "*", count="exact", head=True
+            ).eq("device_id", device_id).execute()
+            
+            return response.count or 0
+        except Exception as e:
+            logger.error(f"Error fetching favorite count: {e}")
+            return 0
+
     def get_all(self, device_id: str) -> List[str]:
         """
         Retrieves all favorite biz_item_ids for a device.

--- a/tests/api/test_favorites.py
+++ b/tests/api/test_favorites.py
@@ -64,6 +64,23 @@ def test_add_favorite_idempotency(client, api_endpoint, headers, target_business
     assert data["isSuccess"] is True
     assert data["result"] == {"added": True}
 
+def test_add_favorite_limit_exceeded(client, headers, target_business_id, mock_repo):
+    """최대 즐겨찾기 개수를 초과하면 400 에러를 반환해야 한다."""
+    from app.api.favorites import MAX_FAVORITES_PER_DEVICE
+    
+    # Arrange: 한도를 가득 채움
+    for i in range(MAX_FAVORITES_PER_DEVICE):
+        mock_repo.add(device_id=headers["X-Device-Id"], business_id=target_business_id, biz_item_id=f"item-{i}")
+        
+    # Act: 21번째 추가
+    response = client.put("/api/favorites/new-item-over-limit", headers=headers, params={"business_id": target_business_id})
+    
+    # Assert
+    assert response.status_code == 400
+    data = response.json()
+    assert data["isSuccess"] is False
+    assert "상한" in data["message"] or "limit" in data["message"].lower()
+
 def test_delete_favorite_success(client, api_endpoint, headers, target_business_id):
     """즐겨찾기 삭제 성공 시 200 OK를 반환해야 한다."""
     # Arrange: 데이터 준비

--- a/tests/integration/test_supabase_repository.py
+++ b/tests/integration/test_supabase_repository.py
@@ -27,6 +27,9 @@ def test_supabase_crud(repo, test_data):
     if repo.exists(device_id, business_id, biz_item_id):
         repo.delete(device_id, business_id, biz_item_id)
     
+    # Get initial count
+    initial_count = repo.count_by_device(device_id)
+    
     # 2. Add
     assert repo.add(device_id, business_id, biz_item_id) is True
     
@@ -36,6 +39,10 @@ def test_supabase_crud(repo, test_data):
     # 4. Exists
     assert repo.exists(device_id, business_id, biz_item_id) is True
     
+    # Check count increased by exactly 1
+    new_count = repo.count_by_device(device_id)
+    assert new_count == initial_count + 1
+    
     # 5. Get All
     items = repo.get_all(device_id)
     assert biz_item_id in items
@@ -43,3 +50,7 @@ def test_supabase_crud(repo, test_data):
     # 6. Delete
     repo.delete(device_id, business_id, biz_item_id)
     assert repo.exists(device_id, business_id, biz_item_id) is False
+    
+    # Check count returned to initial
+    final_count = repo.count_by_device(device_id)
+    assert final_count == initial_count


### PR DESCRIPTION
다음과 같이 PR(Pull Request) 본문을 구성해 보았습니다. 복사해서 사용하시면 됩니다!

Closes #181 

## 영향 범위
- PUT /api/favorites/{biz_item_id} (즐겨찾기 추가 API)
- 기기별 즐겨찾기 저장 한도 (최대 20개)

## 구현 내용
### AS-IS
- 즐겨찾기 API 호출 시 개수 상한 제한이 없었음.
- 크롤러/봇 등에 의한 무분별한 요청 시 DB 용량 고갈 및 장애 발생 가능성이 존재함.

### TO-BE
- [ x ] Repository 패턴 확장: IFavoriteRepository 인터페이스 및 SupabaseFavoriteRepository, MockFavoriteRepository에 count_by_device 메서드 구현
- [ x ] 에러 정의: 상한 초과시 반환할 400 Bad Request 에러(FavoriteLimitExceededError) 추가
- 비즈니스 로직 적용: add_favorite API 진입 시 device_id당 개수를 검증하여 MAX_FAVORITES_PER_DEVICE = 20을 초과하는 경우 에러 반환
- [ x ] 테스트 보강: 상한 도달 시 에러 반환에 대한 단위 테스트 및 DB 연동 시 count_by_device 정합성 통합 테스트 추가
 
## 특이사항
- Supabase 저장소에서 개수를 가져올 때 데이터를 전부 읽지 않도록 select("*", count="exact", head=True)를 적용하여 쿼리 부담을 최소화했습니다.
- 상한 개수(20개)는 향후 기획에 따라 변경될 수 있도록 app/api/favorites.py 최상단에 상수로 분리해 두었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-device favorites limit introduced: users can save up to 20 favorites per device; attempts beyond this show an error and prevent addition.
  * Add-favorite is now idempotent: re-adding an existing favorite succeeds without duplication.

* **Tests**
  * Added/updated tests to cover the favorites limit and to verify accurate per-device favorite counts after add/delete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->