### PR TITLE
[#183]; bug: 심야 예약 가능하게 개선(ex. 23:00~02:00)

### DIFF
--- a/app/models/dto.py
+++ b/app/models/dto.py
@@ -186,6 +186,20 @@ class AvailabilityRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_logic(self) -> "AvailabilityRequest":
+        """합주실 검색 요청(AvailabilityRequest)의 위경도 및 시간 유효성을 검증합니다.
+
+        Returns:
+            AvailabilityRequest: 유효성 검증을 통과한 인스턴스 자신.
+
+        Raises:
+            ValueError: 위경도 범위를 벗어나거나, 종료 시간이 시작 시간보다 빠르거나(심야 별도),
+                        최대 5시간을 초과하는 등 주요 예약 정책 위반 시 발생.
+
+        Rationale (의도):
+            API 진입점(DTO 계층)에서 올바른 지도 좌표 범위를 선제적으로 검사하고,
+            단순 시간 입력 실수(예: 15:00~13:00)와 정상적인 심야 예약(예: 23:00~02:00)을 
+            명확히 구분하여 사용자 친화적인 에러를 반환하기 위해 설계되었습니다.
+        """
         if not (-90 <= self.swLat <= 90) or not (-90 <= self.neLat <= 90):
             raise ValueError("위도는 -90도에서 90도 사이여야 합니다.")
         if not (-180 <= self.swLng <= 180) or not (-180 <= self.neLng <= 180):

--- a/app/models/dto.py
+++ b/app/models/dto.py
@@ -217,7 +217,7 @@ class AvailabilityRequest(BaseModel):
 
         # 자정을 넘기는 케이스 처리 (예: 23:00 -> 02:00)
         if start_minutes > end_minutes:
-            # 시작 시간이 19:00 이후이고 종료 시간이 05:00 이전일 때만 밤샘(Overnight) 의도로 간주
+            # 시작 시간이 19:00 이후이고 종료 시간이 05:00 이하일 때만 밤샘(Overnight) 의도로 간주 (05:00 포함)
             is_intended_overnight = (start_minutes >= 1140) and (end_minutes <= 300)
             
             if is_intended_overnight:

--- a/app/models/dto.py
+++ b/app/models/dto.py
@@ -197,8 +197,24 @@ class AvailabilityRequest(BaseModel):
 
         start_minutes = int(self.start_hour[:2]) * 60 + int(self.start_hour[3:])
         end_minutes = 1440 if self.end_hour == "24:00" else int(self.end_hour[:2]) * 60 + int(self.end_hour[3:])
-        if start_minutes >= end_minutes:
-            raise ValueError("시작 시간은 종료 시간보다 빨라야 합니다.")
+        
+        if start_minutes == end_minutes:
+            raise ValueError("시작 시간과 종료 시간은 같을 수 없습니다. (최소 1시간 이상)")
+
+        # 자정을 넘기는 케이스 처리 (예: 23:00 -> 02:00)
+        if start_minutes > end_minutes:
+            # 시작 시간이 19:00 이후이고 종료 시간이 05:00 이전일 때만 밤샘(Overnight) 의도로 간주
+            is_intended_overnight = (start_minutes >= 1140) and (end_minutes <= 300)
+            
+            if is_intended_overnight:
+                end_minutes += 1440
+                if (end_minutes - start_minutes) > 300:
+                    raise ValueError("자정을 넘기는 심야 예약은 최대 5시간까지만 가능합니다.")
+            else:
+                raise ValueError("종료 시간이 시작 시간보다 빠를 수 없습니다.")
+        else:
+            if (end_minutes - start_minutes) > 300:
+                raise ValueError("최대 5시간까지만 예약할 수 있습니다.")
 
         input_date = datetime.strptime(self.date, "%Y-%m-%d").date()
         if input_date == date.today():

--- a/app/models/dto.py
+++ b/app/models/dto.py
@@ -208,13 +208,11 @@ class AvailabilityRequest(BaseModel):
             
             if is_intended_overnight:
                 end_minutes += 1440
-                if (end_minutes - start_minutes) > 300:
-                    raise ValueError("자정을 넘기는 심야 예약은 최대 5시간까지만 가능합니다.")
             else:
                 raise ValueError("종료 시간이 시작 시간보다 빠를 수 없습니다.")
-        else:
-            if (end_minutes - start_minutes) > 300:
-                raise ValueError("최대 5시간까지만 예약할 수 있습니다.")
+                
+        if (end_minutes - start_minutes) > 300:
+            raise ValueError("최대 5시간까지만 예약할 수 있습니다.")
 
         input_date = datetime.strptime(self.date, "%Y-%m-%d").date()
         if input_date == date.today():

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -111,8 +111,7 @@ class AvailabilityService:
         current_min = start_min
         while current_min <= end_min:
             slot_min_adjusted = current_min % 1440
-            
-            # 24:00 (1440분) 처리 로직 가독성 개선
+
             if slot_min_adjusted == 0 and current_min != 0:
                 slot_to_add = 1440
             else:
@@ -148,6 +147,13 @@ class AvailabilityService:
         if hour < 0 or hour > 24:
             raise ValueError(f"?쒓컙 踰붿쐞媛 ?щ컮瑜댁? ?딆뒿?덈떎: {slot}")
         return hour * 60 + minute
+
+    @staticmethod
+    def _get_next_day_str(date_str: str) -> str:
+        """날짜 문자열(YYYY-MM-DD)을 받아 익일 날짜문자열 반환"""
+        dt = datetime.strptime(date_str, "%Y-%m-%d")
+        next_dt = dt + timedelta(days=1)
+        return next_dt.strftime("%Y-%m-%d")
 
     def _minutes_to_slot(self, minute_value: int) -> str:
         """遺??⑥쐞 媛믪쓣 HH:MM 臾몄옄?대줈 蹂??"""
@@ -270,12 +276,6 @@ class AvailabilityService:
         # 3. 크롤러 비동기 작업 준비 및 실행
         tasks = []
         task_dates = []
-        
-        # 날짜 문자열 익일 계산 유틸리티
-        def get_next_day_str(date_str: str) -> str:
-            dt = datetime.strptime(date_str, "%Y-%m-%d")
-            next_dt = dt + timedelta(days=1)
-            return next_dt.strftime("%Y-%m-%d")
 
         end_min = 1440 if request.end_hour == "24:00" else self._slot_to_minutes(request.end_hour)
         is_overnight = (self._slot_to_minutes(request.start_hour) > end_min)
@@ -285,7 +285,7 @@ class AvailabilityService:
             start_mins = self._slot_to_minutes(request.start_hour)
             day1_slots = [slot for slot in hour_slots if self._slot_to_minutes(slot) >= start_mins or slot == "24:00"]
             day2_slots = [slot for slot in hour_slots if slot not in day1_slots]
-            next_date = get_next_day_str(request.date)
+            next_date = self._get_next_day_str(request.date)
 
         for crawler_type, crawler in self.crawlers_map.items():
             filtered_rooms = filter_rooms_by_type(target_rooms, crawler_type)

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -285,6 +285,11 @@ class AvailabilityService:
             start_mins = self._slot_to_minutes(request.start_hour)
             day1_slots = [slot for slot in hour_slots if self._slot_to_minutes(slot) >= start_mins or slot == "24:00"]
             day2_slots = [slot for slot in hour_slots if slot not in day1_slots]
+            
+            # [버그 수정] 익일(day2) 크롤링 시 00:00~01:00 간격을 조회하려면 00:00 슬롯이 반드시 포함되어야 함
+            if "24:00" in day1_slots and day2_slots and "00:00" not in day2_slots:
+                day2_slots.insert(0, "00:00")
+                
             next_date = self._get_next_day_str(request.date)
 
         for crawler_type, crawler in self.crawlers_map.items():

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -277,7 +277,7 @@ class AvailabilityService:
         tasks = []
         task_dates = []
 
-        end_min = 1440 if request.end_hour == "24:00" else self._slot_to_minutes(request.end_hour)
+        end_min = self._slot_to_minutes(request.end_hour)
         is_overnight = (self._slot_to_minutes(request.start_hour) > end_min)
         
         # [최적화] 루프 내부 반복 연산을 줄이기 위해 크롤러 루프 외부에서 1회만 계산

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -79,25 +79,28 @@ class AvailabilityService:
     # ?쒖옉?쒓컙怨?醫낅즺?쒓컙?쇰줈 ?쒓컙 ?щ’ 由ъ뒪???앹꽦
     def generate_time_slots(self, start_str: str, end_str: str) -> List[str]:
         """
-        start_hour? end_hour ?ъ씠??1?쒓컙 ?⑥쐞 ?щ’ 由ъ뒪?몃? ?앹꽦?⑸땲??
-        ?? 14:00 ~ 16:00 -> ["14:00", "15:00", "16:00"]
+        start_hour와 end_hour 사이의 1시간 단위 슬롯 리스트를 생성합니다.
+        자정을 넘기는 경우(예: 23:00 ~ 02:00) 24:00을 기준으로 두 날의 슬롯을 합쳐 생성합니다.
         """
         start_min = self._slot_to_minutes(start_str)
         end_min = self._slot_to_minutes(end_str)
 
+        # 예외 검증(시작=종료, 최대 5시간, 잘못된 심야 시간)은 이미 DTO 계층에서 처리 완료됨
+        # 여기서는 오직 슬롯 배열 생성 로직에만 집중
         if start_min > end_min:
-            raise ValueError("시작 시간이 종료 시간보다 늦을 수 없습니다.")
+            end_min += 1440
+
         if (end_min - start_min) % 60 != 0:
-            raise ValueError("?쒖옉/醫낅즺 ?쒓컙? 1?쒓컙 ?⑥쐞?ъ빞 ?⑸땲??")
+            raise ValueError("시작/종료 시간은 1시간 단위여야 합니다.")
 
         slots = []
         current_min = start_min
         while current_min <= end_min:
-            slots.append(self._minutes_to_slot(current_min))
+            slot_min_adjusted = current_min % 1440
+            slots.append(self._minutes_to_slot(slot_min_adjusted if slot_min_adjusted != 0 or current_min == 0 else 1440))
             current_min += 60
             
         return slots
-
     def _slot_to_minutes(self, slot: str) -> int:
         """HH:MM 형식의 문자열을 분(Minutes) 단위 정수로 변환합니다. (24:00 허용)
         
@@ -240,10 +243,32 @@ class AvailabilityService:
 
         # 3. ?щ·???묒뾽 以鍮?諛??ㅽ뻾
         tasks = []
+        
+        # 날짜 문자열 익일 계산 유틸리티
+        def get_next_day_str(date_str: str) -> str:
+            dt = datetime.strptime(date_str, "%Y-%m-%d")
+            next_dt = dt + timedelta(days=1)
+            return next_dt.strftime("%Y-%m-%d")
+
+        end_min = 1440 if request.end_hour == "24:00" else self._slot_to_minutes(request.end_hour)
+        is_overnight = (self._slot_to_minutes(request.start_hour) > end_min)
+
         for crawler_type, crawler in self.crawlers_map.items():
             filtered_rooms = filter_rooms_by_type(target_rooms, crawler_type)
             if filtered_rooms:
-                tasks.append(crawler.check_availability(request.date, hour_slots, filtered_rooms))
+                if is_overnight:
+                    # 크로스 미드나잇인 경우 당일과 익일로 요청을 분리
+                    start_mins = self._slot_to_minutes(request.start_hour)
+                    day1_slots = [slot for slot in hour_slots if self._slot_to_minutes(slot) >= start_mins or slot == "24:00"]
+                    day2_slots = [slot for slot in hour_slots if slot not in day1_slots]
+                    
+                    if day1_slots:
+                        tasks.append(crawler.check_availability(request.date, day1_slots, filtered_rooms))
+                    if day2_slots:
+                        next_date = get_next_day_str(request.date)
+                        tasks.append(crawler.check_availability(next_date, day2_slots, filtered_rooms))
+                else:
+                    tasks.append(crawler.check_availability(request.date, hour_slots, filtered_rooms))
 
         if not tasks:
             return AvailabilityResponse(

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -266,20 +266,21 @@ class AvailabilityService:
 
         end_min = 1440 if request.end_hour == "24:00" else self._slot_to_minutes(request.end_hour)
         is_overnight = (self._slot_to_minutes(request.start_hour) > end_min)
+        
+        # [최적화] 루프 내부 반복 연산을 줄이기 위해 크롤러 루프 외부에서 1회만 계산
+        if is_overnight:
+            start_mins = self._slot_to_minutes(request.start_hour)
+            day1_slots = [slot for slot in hour_slots if self._slot_to_minutes(slot) >= start_mins or slot == "24:00"]
+            day2_slots = [slot for slot in hour_slots if slot not in day1_slots]
+            next_date = get_next_day_str(request.date)
 
         for crawler_type, crawler in self.crawlers_map.items():
             filtered_rooms = filter_rooms_by_type(target_rooms, crawler_type)
             if filtered_rooms:
                 if is_overnight:
-                    # 크로스 미드나잇인 경우 당일과 익일로 요청을 분리
-                    start_mins = self._slot_to_minutes(request.start_hour)
-                    day1_slots = [slot for slot in hour_slots if self._slot_to_minutes(slot) >= start_mins or slot == "24:00"]
-                    day2_slots = [slot for slot in hour_slots if slot not in day1_slots]
-                    
                     if day1_slots:
                         tasks.append(crawler.check_availability(request.date, day1_slots, filtered_rooms))
                     if day2_slots:
-                        next_date = get_next_day_str(request.date)
                         tasks.append(crawler.check_availability(next_date, day2_slots, filtered_rooms))
                 else:
                     tasks.append(crawler.check_availability(request.date, hour_slots, filtered_rooms))

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -78,9 +78,23 @@ class AvailabilityService:
 
     # ?쒖옉?쒓컙怨?醫낅즺?쒓컙?쇰줈 ?쒓컙 ?щ’ 由ъ뒪???앹꽦
     def generate_time_slots(self, start_str: str, end_str: str) -> List[str]:
-        """
-        start_hour와 end_hour 사이의 1시간 단위 슬롯 리스트를 생성합니다.
-        자정을 넘기는 경우(예: 23:00 ~ 02:00) 24:00을 기준으로 두 날의 슬롯을 합쳐 생성합니다.
+        """시작 시간과 종료 시간 사이의 1시간 단위 예약 슬롯 리스트를 생성합니다.
+
+        Args:
+            start_str (str): 예약 시작 시간 문자열 (HH:MM 형식).
+            end_str (str): 예약 종료 시간 문자열 (HH:MM 형식).
+
+        Returns:
+            List[str]: 1시간 단위로 분리된 슬롯 배열 (예: ["14:00", "15:00"]).
+
+        Raises:
+            ValueError: 시작/종료 시간이 정확히 1시간 단위가 아닐 때 발생. 
+
+        Rationale (의도):
+            사용자가 입력한 "시작~종료" 범위 구간을, 크롤러에 전달하고 응답과 대조하기 쉬운
+            이산적인 1시간 단위 배열로 정규화하는 역할을 수행합니다.
+            핵심 에러 검증(시작>종료 에외, 5시간 제한 등)은 DTO 계층으로 위임하고, 
+            본 함수는 % 1440 모듈러 연산을 이용해 익일 슬롯 배열을 안정적으로 변환하는 것에 집중합니다.
         """
         start_min = self._slot_to_minutes(start_str)
         end_min = self._slot_to_minutes(end_str)

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -111,7 +111,14 @@ class AvailabilityService:
         current_min = start_min
         while current_min <= end_min:
             slot_min_adjusted = current_min % 1440
-            slots.append(self._minutes_to_slot(slot_min_adjusted if slot_min_adjusted != 0 or current_min == 0 else 1440))
+            
+            # 24:00 (1440분) 처리 로직 가독성 개선
+            if slot_min_adjusted == 0 and current_min != 0:
+                slot_to_add = 1440
+            else:
+                slot_to_add = slot_min_adjusted
+                
+            slots.append(self._minutes_to_slot(slot_to_add))
             current_min += 60
             
         return slots

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -325,7 +325,38 @@ class AvailabilityService:
 
         # 4. 寃곌낵 吏묎퀎 諛??뺤콉/媛寃??곸슜
         successful_results = [r for r in all_results if not isinstance(r, Exception)]
-        processed_results = self._apply_policies(successful_results, request, hour_slots)
+                # 심야 예약 분할 조회로 인한 동일 합주실(biz_item_id) 중복 데이터 병합
+        merged_dict = {}
+        for r in successful_results:
+            biz_id = r.room_detail.biz_item_id
+            if biz_id in merged_dict:
+                existing = merged_dict[biz_id]
+                
+                # 1. 예약 가능 여부 병합 (AND 로직, 보수적 평가)
+                if existing.available is True and r.available is True:
+                    existing.available = True
+                elif existing.available is False or r.available is False:
+                    existing.available = False
+                else:
+                    existing.available = "unknown"
+                    
+                # 2. 각 시간대별 슬롯 가능 여부 딕셔너리 병합
+                existing.available_slots.update(r.available_slots)
+                
+                # 3. 크롤러가 반환한 가격 병합
+                if isinstance(existing.estimated_price, int) and isinstance(r.estimated_price, int):
+                    existing.estimated_price += r.estimated_price
+                elif isinstance(r.estimated_price, int):
+                    existing.estimated_price = r.estimated_price
+                    
+                # 4. 정책 경고 로그 병합
+                if hasattr(existing, 'policy_warnings') and hasattr(r, 'policy_warnings'):
+                    existing.policy_warnings.extend(r.policy_warnings)
+            else:
+                merged_dict[biz_id] = r
+                
+        merged_results = list(merged_dict.values())
+        processed_results = self._apply_policies(merged_results, request, hour_slots)
         
         available_results = []
         branch_summary = {}

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -160,8 +160,13 @@ class AvailabilityService:
             end_min = self._slot_to_minutes(end_hour)
         except ValueError:
             return False
-        if start_min >= end_min:
+        if start_min == end_min:
             return False
+        
+        if start_min > end_min:
+            # 심야(Overnight) 요금 할증 등 시작 시간이 종료 시간보다 큰 경우 지원
+            return slot_min >= start_min or slot_min < end_min
+            
         return start_min <= slot_min < end_min
 
     def _resolve_slot_price(self, room_detail, date_str: str, slot: str) -> int:

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -255,8 +255,9 @@ class AvailabilityService:
         
         validate_availability_request(request.date, hour_slots, target_rooms)
 
-        # 3. ?щ·???묒뾽 以鍮?諛??ㅽ뻾
+        # 3. 크롤러 비동기 작업 준비 및 실행
         tasks = []
+        task_dates = []
         
         # 날짜 문자열 익일 계산 유틸리티
         def get_next_day_str(date_str: str) -> str:
@@ -280,10 +281,13 @@ class AvailabilityService:
                 if is_overnight:
                     if day1_slots:
                         tasks.append(crawler.check_availability(request.date, day1_slots, filtered_rooms))
+                        task_dates.append(request.date)
                     if day2_slots:
                         tasks.append(crawler.check_availability(next_date, day2_slots, filtered_rooms))
+                        task_dates.append(next_date)
                 else:
                     tasks.append(crawler.check_availability(request.date, hour_slots, filtered_rooms))
+                    task_dates.append(request.date)
 
         if not tasks:
             return AvailabilityResponse(
@@ -297,7 +301,13 @@ class AvailabilityService:
             )
 
         results_of_lists = await asyncio.gather(*tasks)
-        all_results = [item for sublist in results_of_lists for item in sublist]
+        
+        all_results = []
+        for res_list, t_date in zip(results_of_lists, task_dates):
+            for item in res_list:
+                if isinstance(item, Exception):
+                    item.date_context = t_date  # 익일 요청 실패 시의 날짜 추적을 위해 context 주입
+                all_results.append(item)
 
         self._log_errors(all_results, request.date)
 
@@ -391,10 +401,11 @@ class AvailabilityService:
         """
         errors = [e for e in results if isinstance(e, Exception)]
         for err in errors:
+            actual_date = getattr(err, 'date_context', date_context)
             if isinstance(err, BaseCustomException):
                 # ?덉긽???щ·???먮윭 (Warning ?덈꺼)
                 logger.warning({
-                    "timestamp": date_context,
+                    "timestamp": actual_date,
                     "status": err.status_code,
                     "errorCode": err.error_code,
                     "message": err.message,
@@ -402,7 +413,7 @@ class AvailabilityService:
             else:
                 # ?덉긽移?紐삵븳 ?쇰컲 ?먮윭 (Error ?덈꺼)
                 logger.error({
-                    "timestamp": date_context,
+                    "timestamp": actual_date,
                     "status": 500,
                     "errorCode": ErrorCode.COMMON_INTERNAL_ERROR,
                     "message": str(err),

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -110,14 +110,7 @@ class AvailabilityService:
         slots = []
         current_min = start_min
         while current_min <= end_min:
-            slot_min_adjusted = current_min % 1440
-
-            if slot_min_adjusted == 0 and current_min != 0:
-                slot_to_add = 1440
-            else:
-                slot_to_add = slot_min_adjusted
-                
-            slots.append(self._minutes_to_slot(slot_to_add))
+            slots.append(self._minutes_to_slot(current_min))
             current_min += 60
             
         return slots
@@ -156,10 +149,8 @@ class AvailabilityService:
         return next_dt.strftime("%Y-%m-%d")
 
     def _minutes_to_slot(self, minute_value: int) -> str:
-        """遺??⑥쐞 媛믪쓣 HH:MM 臾몄옄?대줈 蹂??"""
-        if minute_value == 1440:
-            return "24:00"
-        return f"{minute_value // 60:02d}:00"
+        """분 단위 값을 HH:MM 문자열로 변환 (1440분 등 자정은 00:00으로 정규화)"""
+        return f"{(minute_value % 1440) // 60:02d}:00"
 
     def _get_day_type(self, date_str: str) -> str:
         """?붿껌 ?좎쭨 湲곗? ?붿씪 ???weekday/weekend) 諛섑솚."""
@@ -281,16 +272,19 @@ class AvailabilityService:
         end_min = self._slot_to_minutes(request.end_hour)
         is_overnight = (start_mins > end_min)
         
+        # [중요] 사용자가 요청한 시간 범위를 조회하기 위한 시작 슬롯들만 추출 (마지막 경계 슬롯 제외)
+        # 예: 23:00 ~ 01:00 요청 시 hour_slots는 ["23:00", "00:00", "01:00"] 이며,
+        # 체크해야 할 시작 타임은 ["23:00", "00:00"] 입니다.
+        slots_to_check = hour_slots[:-1]
+
         # [최적화] 루프 내부 반복 연산을 줄이기 위해 크롤러 루프 외부에서 1회만 계산
         if is_overnight:
-            day1_slots = [slot for slot in hour_slots if self._slot_to_minutes(slot) >= start_mins]
-            day2_slots = [slot for slot in hour_slots if slot not in day1_slots]
-            
-            # [버그 수정] 익일(day2) 크롤링 시 00:00~01:00 간격을 조회하려면 00:00 슬롯이 반드시 포함되어야 함
-            if "24:00" in day1_slots and day2_slots and "00:00" not in day2_slots:
-                day2_slots.insert(0, "00:00")
-                
+            day1_slots = [slot for slot in slots_to_check if self._slot_to_minutes(slot) >= start_mins]
+            day2_slots = [slot for slot in slots_to_check if slot not in day1_slots]
             next_date = self._get_next_day_str(request.date)
+        else:
+            day1_slots = slots_to_check
+            day2_slots = []
 
         for crawler_type, crawler in self.crawlers_map.items():
             filtered_rooms = filter_rooms_by_type(target_rooms, crawler_type)
@@ -303,7 +297,7 @@ class AvailabilityService:
                         tasks.append(crawler.check_availability(next_date, day2_slots, filtered_rooms))
                         task_dates.append(next_date)
                 else:
-                    tasks.append(crawler.check_availability(request.date, hour_slots, filtered_rooms))
+                    tasks.append(crawler.check_availability(request.date, day1_slots, filtered_rooms))
                     task_dates.append(request.date)
 
         if not tasks:

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -217,13 +217,29 @@ class AvailabilityService:
         return max(slot_price, 0)
 
     def calculate_total_price(self, room_detail, date_str: str, hour_slots: List[str]) -> int:
-        """?붿껌 ?щ’ ?꾩껜??珥?媛寃?怨꾩궛."""
+        """요청 슬롯 전체의 총 가격 계산. (심야 예약 시 익일 날짜 반영 로직 포함)"""
         if len(hour_slots) < 2:
             return 0
-        # `hour_slots` is end-inclusive boundaries (e.g. ["14:00","15:00"] => 1 hour),
-        # so only slots except the last boundary are billable.
+            
+        # [중요] 사용자가 요청한 시간 범위를 조회하기 위한 시작 슬롯들만 추출 (마지막 경계 슬롯 제외)
         billable_slots = hour_slots[:-1]
-        return sum(self._resolve_slot_price(room_detail, date_str, slot) for slot in billable_slots)
+        
+        total_price = 0
+        current_date = date_str
+        last_minutes = -1
+        
+        for slot in billable_slots:
+            current_minutes = self._slot_to_minutes(slot)
+            
+            # 자정을 넘겼는지 체크 (이전 슬롯보다 분 단위가 작으면 날짜 변경)
+            # NOTE: 슬롯이 1시간 단위로 연속적임이 검증되었다고 가정함.
+            if last_minutes != -1 and current_minutes < last_minutes:
+                current_date = self._get_next_day_str(current_date)
+            
+            total_price += self._resolve_slot_price(room_detail, current_date, slot)
+            last_minutes = current_minutes
+            
+        return total_price
         
 
     async def check_availability(self, request: AvailabilityRequest) -> AvailabilityResponse:
@@ -521,14 +537,13 @@ class AvailabilityService:
                             f"{request.date} {hour_slots[0]}", "%Y-%m-%d %H:%M"
                         )
                         end_slot = hour_slots[-1]
-                        if end_slot == "24:00":
-                            end_dt = datetime.strptime(
-                                f"{request.date} 00:00", "%Y-%m-%d %H:%M"
-                            ) + timedelta(days=1)
-                        else:
-                            end_dt = datetime.strptime(
-                                f"{request.date} {end_slot}", "%Y-%m-%d %H:%M"
-                            )
+                        end_dt = datetime.strptime(
+                            f"{request.date} {end_slot}", "%Y-%m-%d %H:%M"
+                        )
+                        
+                        # [심야 예약 대응] 종료 시간이 시작 시간보다 같거나 빠르면 익일로 간주
+                        if end_dt <= start_dt:
+                            end_dt += timedelta(days=1)
                         price = self.pricing_service.calculate_total_price(
                             base_price=room.pricePerHour,
                             price_config=normalized_rules,

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -492,7 +492,8 @@ class AvailabilityService:
 
         for res in results:
             room = res.room_detail
-            policy_warnings: List[PolicyWarning] = []
+            # 기존 크롤러 등에서 넘어온 경고가 있을 수 있으므로 보존하면서 추가
+            policy_warnings: List[PolicyWarning] = list(res.policy_warnings) if hasattr(res, 'policy_warnings') and res.policy_warnings else []
 
             booking_duration_hours = len(hour_slots) - 1
             if booking_duration_hours == 1 and not room.canReserveOneHour:

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -277,13 +277,13 @@ class AvailabilityService:
         tasks = []
         task_dates = []
 
+        start_mins = self._slot_to_minutes(request.start_hour)
         end_min = self._slot_to_minutes(request.end_hour)
-        is_overnight = (self._slot_to_minutes(request.start_hour) > end_min)
+        is_overnight = (start_mins > end_min)
         
         # [최적화] 루프 내부 반복 연산을 줄이기 위해 크롤러 루프 외부에서 1회만 계산
         if is_overnight:
-            start_mins = self._slot_to_minutes(request.start_hour)
-            day1_slots = [slot for slot in hour_slots if self._slot_to_minutes(slot) >= start_mins or slot == "24:00"]
+            day1_slots = [slot for slot in hour_slots if self._slot_to_minutes(slot) >= start_mins]
             day2_slots = [slot for slot in hour_slots if slot not in day1_slots]
             
             # [버그 수정] 익일(day2) 크롤링 시 00:00~01:00 간격을 조회하려면 00:00 슬롯이 반드시 포함되어야 함
@@ -320,7 +320,7 @@ class AvailabilityService:
         results_of_lists = await asyncio.gather(*tasks)
         
         all_results = []
-        for res_list, t_date in zip(results_of_lists, task_dates):
+        for res_list, t_date in zip(results_of_lists, task_dates, strict=True):
             for item in res_list:
                 if isinstance(item, Exception):
                     item.date_context = t_date  # 익일 요청 실패 시의 날짜 추적을 위해 context 주입

--- a/app/validate/hour_validator.py
+++ b/app/validate/hour_validator.py
@@ -61,7 +61,18 @@ def validate_hour_continuous(hour_slots: List[str], date: str):
     for slot in hour_slots:
         validate_hour_slot_format(slot)
 
-    slots = sorted(_slot_to_minutes(slot) for slot in hour_slots)
+    raw_slots = [_slot_to_minutes(slot) for slot in hour_slots]
+    
+    # 최대 예약 허용 시간은 5시간이므로, 자정을 넘기는 케이스는
+    # 20:00(1200분) ~ 04:00(240분) 사이에만 발생할 수 있음
+    has_late_night = any(s >= 1200 for s in raw_slots)   # 20:00 이후
+    has_early_morning = any(s <= 240 for s in raw_slots) # 04:00 이전
+    
+    # 두 시간대가 공존하면 새벽 시간대(04:00 이하)를 다음 날로 간주하여 1440을 더함
+    if has_late_night and has_early_morning:
+        slots = sorted((s + 1440 if s <= 240 else s) for s in raw_slots)
+    else:
+        slots = sorted(raw_slots)
 
     for i in range(len(slots) - 1):
         if slots[i + 1] - slots[i] != 60:

--- a/app/validate/hour_validator.py
+++ b/app/validate/hour_validator.py
@@ -53,7 +53,20 @@ def validate_hour_slots(hour_slots: List[str], date: str):
 
 
 def validate_hour_continuous(hour_slots: List[str], date: str):
-    """입력받은 시간값이 연속인지 검증"""
+    """입력받은 시간 슬롯들이 1시간 단위로 끊기지 않고 연속적인지 검증합니다.
+
+    Args:
+        hour_slots (List[str]): 검사할 시간 슬롯 문자열 배열 (예: ["23:00", "24:00", "01:00"]).
+        date (str): 예약 기준 날짜 (YYYY-MM-DD 형식). 시그니처 유지를 위해 존재함.
+
+    Raises:
+        HourDiscontinuousError: 슬롯 간격이 1시간을 초과하여 중간에 빈 시간이 있는 경우 발생.
+
+    Rationale (의도):
+        사용자가 선택한 개별 시간 단위(1시간)가 중간에 이가 빠지지 않고 이어져 있는지 
+        확인하기 위한 필수 검수 과정입니다. 자정을 넘기는 교차 시간대의 경우,
+        새벽 시간대 슬롯(04:00 이하)에 1440분(하루)을 더해 연속성 정렬 오류를 방지하도록 구현되었습니다.
+    """
     _ = date
     if len(hour_slots) <= 1:
         return

--- a/app/validate/hour_validator.py
+++ b/app/validate/hour_validator.py
@@ -76,14 +76,19 @@ def validate_hour_continuous(hour_slots: List[str], date: str):
 
     raw_slots = [_slot_to_minutes(slot) for slot in hour_slots]
     
-    # 최대 예약 허용 시간은 5시간이므로, 자정을 넘기는 케이스는
-    # 20:00(1200분) ~ 04:00(240분) 사이에만 발생할 수 있음
-    has_late_night = any(s >= 1200 for s in raw_slots)   # 20:00 이후
-    has_early_morning = any(s <= 240 for s in raw_slots) # 04:00 이전
+    # [자정을 넘기는 연속성 검사 기준 (19:00 ~ 05:00)]
+    # DTO 계층에서 허용하는 최대 예약 시간은 5시간입니다.
+    # 가장 극단적인 심야 예약 조합은 "19:00 ~ 00:00(24:00)"에서 시작해, 가장 늦게 끝나는 조합이 "00:00 ~ 05:00"입니다.
+    # 즉, 정상적인 5시간 이내의 예약이라면 '19:00 이전' 시간대와 '05:00 이후' 시간대가 같은 슬롯 배열에 공존할 수 없습니다.
+    # 따라서 19:00(1140분) 이후 값을 "심야", 05:00(300분) 이전 값을 "새벽"으로 정의하여 교차 여부를 판별합니다.
+    has_late_night = any(s >= 1140 for s in raw_slots)   # 19:00 이후 슬롯 존재 여부
+    has_early_morning = any(s <= 300 for s in raw_slots) # 05:00 이전 슬롯 존재 여부
     
-    # 두 시간대가 공존하면 새벽 시간대(04:00 이하)를 다음 날로 간주하여 1440을 더함
+    # 심야(19:00~)와 새벽(~05:00) 시간대가 배열에 공존한다면 자정을 넘긴(Overnight) 예약입니다.
+    # 00:00~04:00과 같은 새벽 슬롯들은 숫자가 작아 정렬 시 앞으로 오게 되므로 시계열 연속성이 깨집니다.
+    # 이를 방지하기 위해 새벽 시간대값에 하루치인 1440분을 더해 익일 시간(예: 01:00 -> 25:00)으로 변환 후 정렬합니다.
     if has_late_night and has_early_morning:
-        slots = sorted((s + 1440 if s <= 240 else s) for s in raw_slots)
+        slots = sorted((s + 1440 if s <= 300 else s) for s in raw_slots)
     else:
         slots = sorted(raw_slots)
 

--- a/tests/services/test_availability_service.py
+++ b/tests/services/test_availability_service.py
@@ -118,12 +118,12 @@ class TestApplyPolicies:
         assert results[0].estimated_price is None
 
     def test_price_calculation_list_config_supports_24h_end(self, service, mock_pricing_service):
-        """list price_config 경로에서 24:00 종료 시각을 다음날 00:00으로 변환"""
+        """list price_config 경로에서 00:00 종료 시각을 다음날 00:00으로 변환"""
         req = AvailabilityRequest(
-            date="2099-01-01", capacity=4, start_hour="22:00", end_hour="24:00",
+            date="2099-01-01", capacity=4, start_hour="22:00", end_hour="00:00",
             swLat=0.0, swLng=0.0, neLat=1.0, neLng=1.0
         )
-        slots = ["22:00", "23:00", "24:00"]
+        slots = ["22:00", "23:00", "00:00"]
 
         room = RoomDetail(
             name="TestRoom", branch="Branch", business_id="b1", biz_item_id="r1",

--- a/tests/services/test_availability_service_pricing.py
+++ b/tests/services/test_availability_service_pricing.py
@@ -22,7 +22,7 @@ def _room_detail(**overrides) -> RoomDetail:
 
 def test_generate_time_slots_supports_24h():
     service = AvailabilityService(crawlers_map={})
-    assert service.generate_time_slots("22:00", "24:00") == ["22:00", "23:00", "24:00"]
+    assert service.generate_time_slots("22:00", "24:00") == ["22:00", "23:00", "00:00"]
 
 
 def test_calculate_total_price_with_fallback_default_price():
@@ -42,7 +42,7 @@ def test_calculate_total_price_with_override_and_surcharge():
                 {
                     "day_type": "weekend",
                     "start_hour": "18:00",
-                    "end_hour": "24:00",
+                    "end_hour": "00:00",
                     "price": 15000,
                 }
             ],
@@ -64,7 +64,7 @@ def test_calculate_total_price_skips_invalid_override_hours():
                 {
                     "day_type": "weekday",
                     "start_hour": "18:30",
-                    "end_hour": "24:00",
+                    "end_hour": "00:00",
                     "price": 15000,
                 }
             ],


### PR DESCRIPTION
## 0. 도입 배경 (Background)
자정을 넘기는 심야 예약(Overnight Reservation: 예 23:00 ~ 02:00)을 조회할 때, 기존에는 무조건 `시작 시간 > 종료 시간`을 에러로 처리하여 정상적인 예약 조회가 불가능했습니다. 
정상적인 심야 밤샘 예약과 사용자의 단순 시간 입력 실수(예: 15:00 ~ 13:00, 21:00 ~ 18:00)를 명확하게 구분하고, 심야 예약 요청 시 당일과 익일 데이터를 모두 정상적으로 모아오기 위해 검증 분기 및 조회 분할 로직 파이프라인을 구축했습니다.

## 1. 주요 변경 사항 (Proposed Changes)
- **DTO 검증 (사용자 오기입 vs 의도된 심야 예약 분기) ([app/models/dto.py](cci:7://file:///c:/Users/%ED%95%98%EC%A0%95%ED%9B%88/Desktop/%ED%94%BD%ED%95%A9%EC%A3%BC/pick-habju-backend/app/models/dto.py:0:0-0:0))**
  - 무조건적인 `start_hour > end_hour` 차단 정책을 완화했습니다.
  - 시간대가 **19:00 이후 ~ 05:00 이전** 속한 경우, 정상적인 밤샘 예약으로 간주합니다. 총 5시간을 초과하면 `최대 5시간까지만 예약할 수 있습니다.`를 반환합니다.
  - 19:00 이전에 시작해서 익일로 넘어가는 불가능한 일정(예: 15:00 ~ 13:00)은 사용자의 입력 실수로 판단하여 `종료 시간이 시작 시간보다 빠를 수 없습니다.`를 반환합니다. -> 15:00~13:00을 단순 입력 실수로 보지 않고 '익일로 넘어가는 5시간 이상의 로직' = 사용자의 입력 실수로 분기하였음

- **연속성 검사 내 자정 경계 로직 보강 ([app/validate/hour_validator.py]**
  - 자정을 넘나드는 시간대 슬롯 배열(예: `23:00, 24:00, 01:00`)이 들어올 경우 발생하는 오버플로우 버그를 수정했습니다.
  - 새벽 시간대(04:00 이하) 값에 1440분(하루)을 더해 익일 시간대로 변환함으로써, 인접 1시간 단위 정렬 및 연속성 검사([validate_hour_continuous])가 무사히 통과되도록 보전했습니다.

- **크롤러 비동기 요청 분할 처리 ([app/services/availability_service.py])**
  - 중복되는 유효성 검증을 DTO로 전가하여 서비스 비즈니스 가독성을 높였습니다. 
  - `start_hour > end_hour` (overnight) 발생 시, 크롤러에 단일 요청만 보내지 않습니다.
  - 당일(`request.date`)분 슬롯 리스트와 익일(`next_date`)분 슬롯 리스트로 역할을 2개 분할한 뒤 병렬 크롤러 `tasks`에 던져 취합되도록 파이프라인 구조를 개선했습니다.

## 2. 체크리스트 (Checklist)
- [x] 관련된 이슈를 PR 커밋 메시지 또는 본문에 링크했습니다. (`#183`)
- [x] PR 제목은 `[#이슈번호]; <태그>: <설명>` 컨벤션을 준수했습니다.
- [x] 새로 작성된 함수와 클래스에는 `Google Style Docstring`(의도, 파라미터 등)이 포함되어 있습니다.
- [x] 테스트 코드가 작성되었거나 기능 테스트가 완료되었습니다. (`test_dto_validation`, `test_hour_validator`, `test_available_room` 통과)

## 3. 참고 자료 (Optional)

---
**Closes #183**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for overnight reservations that span past midnight, evaluated and merged per calendar date.

* **Improvements**
  * Stricter time validation: rejects identical start/end times and enforces 1-hour granularity.
  * Detects late-night-to-early-morning windows as continuous overnight spans.
  * Enforces a 5-hour maximum reservation length.
  * Treats "24:00" as "00:00" (next day) for slot generation and pricing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->