### PR TITLE
[#185]; style: 인코딩 깨짐 현상 해결 및 .editorconfig 파일을 통한 UTF-8 인코딩 강제

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.py]
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -67,16 +67,16 @@ class AvailabilityService:
     """
 
     def __init__(self, crawlers_map: dict[str, BaseCrawler]):
-        """?쒕퉬??珥덇린??
+        """서비스 초기화
         
         Args:
-            crawlers_map: ?щ·???????怨?BaseCrawler ?몄뒪?댁뒪(媛???留ㅽ븨 ?뺤뀛?덈━
-                         ?? {"dream": DreamCrawler(), "groove": GrooveCrawler()}
+            crawlers_map: 플랫폼 타입을 키로 하고 BaseCrawler 인스턴스를 값으로 하는 매핑 딕셔너리
+                         예: {"dream": DreamCrawler(), "groove": GrooveCrawler()}
         """
         self.crawlers_map = crawlers_map
         self.pricing_service = PricingService()
 
-    # ?쒖옉?쒓컙怨?醫낅즺?쒓컙?쇰줈 ?쒓컙 ?щ’ 由ъ뒪???앹꽦
+    # 시작시간과 종료시간으로 시간 슬롯 리스트 생성
     def generate_time_slots(self, start_str: str, end_str: str) -> List[str]:
         """시작 시간과 종료 시간 사이의 1시간 단위 예약 슬롯 리스트를 생성합니다.
 
@@ -132,13 +132,13 @@ class AvailabilityService:
         """
         match = re.fullmatch(r"(\d{2}):(\d{2})", slot)
         if not match:
-            raise ValueError(f"?쒓컙 ?뺤떇???щ컮瑜댁? ?딆뒿?덈떎: {slot}")
+            raise ValueError(f"시간 형식이 올바르지 않습니다: {slot}")
         hour = int(match.group(1))
         minute = int(match.group(2))
         if minute != 0:
-            raise ValueError(f"?쒓컙? ?뺤떆(00遺?留?吏?먰빀?덈떎: {slot}")
+            raise ValueError(f"시간은 정시(00분)만 지원합니다: {slot}")
         if hour < 0 or hour > 24:
-            raise ValueError(f"?쒓컙 踰붿쐞媛 ?щ컮瑜댁? ?딆뒿?덈떎: {slot}")
+            raise ValueError(f"시간 범위가 올바르지 않습니다: {slot}")
         return hour * 60 + minute
 
     @staticmethod
@@ -153,11 +153,11 @@ class AvailabilityService:
         return f"{(minute_value % 1440) // 60:02d}:00"
 
     def _get_day_type(self, date_str: str) -> str:
-        """?붿껌 ?좎쭨 湲곗? ?붿씪 ???weekday/weekend) 諛섑솚."""
+        """요청 날짜 기준 요일 타입(weekday/weekend) 반환."""
         return "weekend" if datetime.strptime(date_str, "%Y-%m-%d").weekday() >= 5 else "weekday"
 
     def _is_slot_in_range(self, slot: str, start_hour: str, end_hour: str) -> bool:
-        """slot??[start_hour, end_hour) 踰붿쐞???ы븿?섎뒗吏 ?먮떒."""
+        """slot이 [start_hour, end_hour) 범위에 포함되는지 판단."""
         try:
             slot_min = self._slot_to_minutes(slot)
             start_min = self._slot_to_minutes(start_hour)
@@ -174,7 +174,7 @@ class AvailabilityService:
         return start_min <= slot_min < end_min
 
     def _resolve_slot_price(self, room_detail, date_str: str, slot: str) -> int:
-        """?⑥씪 ?щ’ 媛寃?怨꾩궛(price_config override + surcharge 諛섏쁺)."""
+        """단일 슬롯 가격 계산(price_config override + surcharge 반영)."""
         day_type = self._get_day_type(date_str)
         price_config = room_detail.priceConfig or {}
         if not isinstance(price_config, dict):
@@ -259,8 +259,8 @@ class AvailabilityService:
             전체 합주실 조회 서비스의 실패(500 서버 장애)로 이어지지 않도록 방어 로직을 구성함.
         """
 
-        # 1. ?쒓컙 踰붿쐞(Range) -> ?쒓컙 ?щ’ 由ъ뒪??List) 蹂??
-        # ?? 14:00 ~ 16:00 -> ["14:00", "15:00", "16:00"]
+        # 1. 시간 범위(Range) -> 시간 슬롯 리스트(List) 변환
+        # 예: 14:00 ~ 16:00 -> ["14:00", "15:00", "16:00"]
         try:
             hour_slots = self.generate_time_slots(request.start_hour, request.end_hour)
         except ValueError as e:
@@ -269,7 +269,7 @@ class AvailabilityService:
         
         # 1.5. 지도 좌표 유효성 검증 (필수) -> DTO model_validator로 이관됨
 
-        # 2. ?몄썝??諛?吏??踰붿쐞??留욌뒗 猷??꾪꽣留?(DB)
+        # 2. 인원수 및 지도 범위에 맞는 룸 필터링(DB)
         target_rooms = get_rooms_by_criteria(
             capacity=request.capacity,
             swLat=request.swLat,
@@ -338,7 +338,7 @@ class AvailabilityService:
 
         self._log_errors(all_results, request.date)
 
-        # 4. 寃곌낵 吏묎퀎 諛??뺤콉/媛寃??곸슜
+        # 4. 결과 집계 및 정책/가격 적용
         successful_results = [r for r in all_results if not isinstance(r, Exception)]
                 # 심야 예약 분할 조회로 인한 동일 합주실(biz_item_id) 중복 데이터 병합
         merged_dict = {}
@@ -377,12 +377,12 @@ class AvailabilityService:
         branch_summary = {}
 
         for res in processed_results:
-            # 猷??뺣낫 異붿텧
+            # 룸 정보 추출
             room_detail = res.room_detail
 
-            # ?덉빟 媛?ν븳 猷몃쭔 寃곌낵 由ъ뒪?몄뿉 ?ы븿 (unknown ?ы븿)
+            # 예약 가능한 룸만 결과 리스트에 포함 (unknown 포함)
             if res.available is True or res.available == "unknown":
-                # v2.0.0: ?쒖떆??沅뚯옣 ?몄썝 踰붿쐞 怨꾩궛 (鍮꾩젙??max/base 議고빀 諛⑹뼱)
+                # v2.0.0: 표시용 권장 인원 범위 계산 (비정적 max/base 조합 방어)
                 rec_min: Optional[int] = None
                 rec_max: Optional[int] = None
 
@@ -419,7 +419,7 @@ class AvailabilityService:
 
                 available_results.append(res)
 
-                # 吏???붿빟 ?뺣낫 ?낅뜲?댄듃 (branch_summary) - 吏??湲곕뒫??
+                # 지점 요약 정보 업데이트 (branch_summary) - 지도 기능용
                 bid = room_detail.business_id
                 if bid not in branch_summary:
                     branch_summary[bid] = BranchStats(
@@ -461,7 +461,7 @@ class AvailabilityService:
         for err in errors:
             actual_date = getattr(err, 'date_context', date_context)
             if isinstance(err, BaseCustomException):
-                # ?덉긽???щ·???먮윭 (Warning ?덈꺼)
+                # 예상된 플랫폼 에러 (Warning 레벨)
                 logger.warning({
                     "timestamp": actual_date,
                     "status": err.status_code,
@@ -469,7 +469,7 @@ class AvailabilityService:
                     "message": err.message,
                 })
             else:
-                # ?덉긽移?紐삵븳 ?쇰컲 ?먮윭 (Error ?덈꺼)
+                # 예상치 못한 일반 에러 (Error 레벨)
                 logger.error({
                     "timestamp": actual_date,
                     "status": 500,

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -386,48 +386,48 @@ class RoomCollectionService:
 
         # If there are unresolved items, export them
         if unresolved_items:
-                # 로컬 환경에서 호출 시 경로 설정 가능. 기본값은 프로젝트 루트/scripts/unresolved
-                default_dir = Path(__file__).parent.parent.parent / "scripts" / "unresolved"
-                export_dir = Path(os.getenv("UNRESOLVED_EXPORT_DIR", str(default_dir)))
-                export_dir.mkdir(parents=True, exist_ok=True)
+            # 로컬 환경에서 호출 시 경로 설정 가능. 기본값은 프로젝트 루트/scripts/unresolved
+            default_dir = Path(__file__).parent.parent.parent / "scripts" / "unresolved"
+            export_dir = Path(os.getenv("UNRESOLVED_EXPORT_DIR", str(default_dir)))
+            export_dir.mkdir(parents=True, exist_ok=True)
 
-                # Generate filename with current date
-                date_str = datetime.now().strftime("%Y%m%d")
-                export_file = export_dir / f"unresolved_{date_str}.json"
+            # Generate filename with current date
+            date_str = datetime.now().strftime("%Y%m%d")
+            export_file = export_dir / f"unresolved_{date_str}.json"
 
-                # Load existing data if file exists, otherwise start with empty list
-                existing_data = []
-                if export_file.exists():
-                    try:
-                        with open(export_file, "r", encoding="utf-8") as f:
-                            existing_data = json.load(f)
-                    except Exception as e:
-                        logger.warning(f"Failed to read existing unresolved file: {e}")
+            # Load existing data if file exists, otherwise start with empty list
+            existing_data = []
+            if export_file.exists():
+                try:
+                    with open(export_file, "r", encoding="utf-8") as f:
+                        existing_data = json.load(f)
+                except Exception as e:
+                    logger.warning(f"Failed to read existing unresolved file: {e}")
 
-                # Append new unresolved items with duplicate check
-                existing_ids = {item["biz_item_id"] for item in existing_data}
-                new_items = [item for item in unresolved_items if item["biz_item_id"] not in existing_ids]
+            # Append new unresolved items with duplicate check
+            existing_ids = {item["biz_item_id"] for item in existing_data}
+            new_items = [item for item in unresolved_items if item["biz_item_id"] not in existing_ids]
 
-                if new_items:
-                    existing_data.extend(new_items)
+            if new_items:
+                existing_data.extend(new_items)
 
-                    # Atomic write: temp file 후 rename으로 중간 상태 방지
-                    tmp_fd, tmp_path = tempfile.mkstemp(
-                        dir=str(export_dir), suffix=".tmp"
-                    )
-                    try:
-                        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
-                            json.dump(existing_data, f, ensure_ascii=False, indent=2)
-                        # os.replace는 원자적(같은 파일시스템 상)
-                        os.replace(tmp_path, str(export_file))
-                    except Exception:
-                        # 실패 시 임시 파일 정리
-                        if os.path.exists(tmp_path):
-                            os.unlink(tmp_path)
-                        raise
+                # Atomic write: temp file 후 rename으로 중간 상태 방지
+                tmp_fd, tmp_path = tempfile.mkstemp(
+                    dir=str(export_dir), suffix=".tmp"
+                )
+                try:
+                    with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                        json.dump(existing_data, f, ensure_ascii=False, indent=2)
+                    # os.replace는 원자적(같은 파일시스템 상)
+                    os.replace(tmp_path, str(export_file))
+                except Exception:
+                    # 실패 시 임시 파일 정리
+                    if os.path.exists(tmp_path):
+                        os.unlink(tmp_path)
+                    raise
 
-                    logger.info(f"Exported {len(new_items)} new unresolved items to {export_file} (skipped {len(unresolved_items) - len(new_items)} duplicates)")
-                else:
-                    logger.debug(f"All {len(unresolved_items)} items were already in unresolved list. Skipping export.")
+                logger.info(f"Exported {len(new_items)} new unresolved items to {export_file} (skipped {len(unresolved_items) - len(new_items)} duplicates)")
+            else:
+                logger.debug(f"All {len(unresolved_items)} items were already in unresolved list. Skipping export.")
 
 

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -21,7 +21,7 @@ class RoomCollectionService:
     MAX_CONCURRENT_BATCHES = 3  # Number of parallel LLM calls
     
     # Capacity value indicating LLM parsing failure - flags for manual review
-    # Rationale: 100紐낆쓣 ?섏슜?섎뒗 ?⑹＜?ㅼ? ?꾩떎?곸쑝濡??놁쑝誘濡??섎룞 寃???꾩슂 ??ぉ?쇰줈 ?앸퀎 媛??
+    # Rationale: 100명을 수용하는 합주실은 현실적으로 없으므로 수동 검토 필요 목적으로 식별 가능
     MANUAL_REVIEW_FLAG = 100
 
     def __init__(self):
@@ -42,7 +42,7 @@ class RoomCollectionService:
         """
         logger.info(f"Starting collection for query: {query}")
         
-        # 1. 吏??寃?됱쑝濡?ID ?뺣낫
+        # 1. 지도 검색으로 ID 확보
         search_results = await self.map_crawler.search_rehearsal_rooms(query)
         logger.info(f"Found {len(search_results)} businesses for {query}")
         
@@ -157,7 +157,7 @@ class RoomCollectionService:
         branch_data = {
             "business_id": business["businessId"],
             "name": business["businessDisplayName"],
-            "display_name": business.get("businessDisplayName"),  # v2.0.0: ?몄텧???대쫫
+            "display_name": business.get("businessDisplayName"),  # v2.0.0: 노출용 이름
             "lat": coords.get("latitude") if coords else None,
             "lng": coords.get("longitude") if coords else None,
         }
@@ -205,8 +205,8 @@ class RoomCollectionService:
                 existing_max = existing.get("max_capacity", 0)
                 existing_rec = existing.get("recommend_capacity", 0)
 
-                # [Logic] 湲곗〈 媛믪씠 ?좏슚?섍퀬(>1), ??媛믪씠 湲곕낯媛?1)?닿굅???섎룞寃?좏뵆?섍렇(100)??寃쎌슦 湲곗〈 媛?蹂댁〈
-                # ?? 湲곗〈 媛??먯껜媛 100??寃쎌슦???쒖쇅
+                # [Logic] 기존 값이 유효하고(>1), 새 값이 기본값(1)이거나 수동검토플래그(100)인 경우 기존 값 보존
+                # 단, 기존 값 자체가 100인 경우는 제외
                 if (new_max_cap <= 1 or new_max_cap == self.MANUAL_REVIEW_FLAG) and existing_max > 1 and existing_max != self.MANUAL_REVIEW_FLAG:
                     final_max_cap = existing_max
                 
@@ -283,26 +283,26 @@ class RoomCollectionService:
         base_cap: Optional[int],
         extra_charge: Optional[int]
     ) -> List[int]:
-        """異붽? ?붽툑 ?좊Т???곕씪 沅뚯옣 ?몄썝 踰붿쐞 怨꾩궛
+        """추가 요금 유무에 따라 권장 인원 범위 계산
 
         Args:
-            parsed_range: LLM/?뺢퇋?앹씠 ?뚯떛??踰붿쐞 ([min, max] ?뺥깭)
-            rec_cap: 沅뚯옣 ?몄썝 ??
-            max_cap: 理쒕? ?몄썝 ??
-            base_cap: 湲곗? ?몄썝 ??(異붽? ?붽툑 怨꾩궛 湲곗?)
-            extra_charge: 異붽? ?붽툑 (??
+            parsed_range: LLM/정규식이 파싱한 범위 ([min, max] 형태)
+            rec_cap: 권장 인원 수
+            max_cap: 최대 인원 수
+            base_cap: 기준 인원 수 (추가 요금 계산 기준)
+            extra_charge: 추가 요금 (원)
 
         Returns:
-            [min, max] ?뺥깭??沅뚯옣 ?몄썝 踰붿쐞 由ъ뒪??
+            [min, max] 형태의 권장 인원 범위 리스트
 
         Rationale:
-            1. ?뚯떛??踰붿쐞媛 ?좏슚?섎㈃ ?곗꽑 ?ъ슜 (?? ?⑸━??踰붿쐞濡?clamp)
-            2. 異붽? ?붽툑 諛쒖깮 ?? [base_cap, max_cap]
-            3. 異붽? ?붽툑 ?놁쓣 ?? [rec_cap, rec_cap + 2] (理쒕? max_cap)
+            1. 파싱된 범위가 유효하면 우선 사용 (단 합리적 범위로 clamp)
+            2. 추가 요금 발생 시 [base_cap, max_cap]
+            3. 추가 요금 없을 시 [rec_cap, rec_cap + 2] (최대 max_cap)
         """
-        # 1. ?뚯떛??踰붿쐞 寃利????곗꽑 ?ъ슜
-        # 議곌굔: 2媛??レ옄(int ?먮뒗 float), min <= max, ?⑹＜???꾩떎??踰붿쐞(1~50紐? ??
-        # NOTE: LLM ?뚯꽌媛 float(?? 4.0)??諛섑솚?????덉쑝誘濡?int/float 紐⑤몢 ?덉슜
+        # 1. 파싱된 범위 검증 후 우선 사용
+        # 조건: 2개 숫자(int 또는 float), min <= max, 합주실 현실적 범위(1~50명 이내)
+        # NOTE: LLM 파서가 float(예: 4.0)을 반환할 수 있으므로 int/float 모두 허용
         if (
             isinstance(parsed_range, list)
             and len(parsed_range) == 2
@@ -310,16 +310,16 @@ class RoomCollectionService:
             and parsed_range[0] <= parsed_range[1]
             and 1 <= parsed_range[0] and parsed_range[1] <= 50
         ):
-            # float ??int 蹂?????⑸━??踰붿쐞濡?clamp
+            # float → int 변환 및 합리적 범위로 clamp
             clamped_min = max(int(parsed_range[0]), 1)
             clamped_max = min(int(parsed_range[1]), max_cap) if max_cap > 0 else int(parsed_range[1])
-            # clamp ?꾩뿉??min <= max 蹂댁옣
+            # clamp 후에도 min <= max 보장
             clamped_max = max(clamped_max, clamped_min)
             return [clamped_min, clamped_max]
 
-        # --- Sentinel 諛⑹뼱 ---
-        # NOTE: MANUAL_REVIEW_FLAG(100)??rec_cap/max_cap/base_cap???ㅼ뼱?ㅻ㈃
-        #        [100, 102] 媛숈? 鍮꾪쁽?ㅼ쟻 踰붿쐞媛 諛섑솚?섎?濡? ?꾩떎???곹븳(50)?쇰줈 clamp
+        # --- Sentinel 방어 ---
+        # NOTE: MANUAL_REVIEW_FLAG(100)이 rec_cap/max_cap/base_cap에 들어오면
+        #        [100, 102] 같은 비현실적 범위가 반환되므로 현실적 상한(50)으로 clamp
         MAX_REALISTIC_CAP = 50
         if max_cap >= self.MANUAL_REVIEW_FLAG:
             max_cap = MAX_REALISTIC_CAP
@@ -328,21 +328,21 @@ class RoomCollectionService:
         if base_cap and base_cap >= self.MANUAL_REVIEW_FLAG:
             base_cap = MAX_REALISTIC_CAP
 
-        # 2. 異붽? ?붽툑 ?덈뒗 寃쎌슦
+        # 2. 추가 요금 있는 경우
         if extra_charge and extra_charge > 0 and base_cap:
             # min: base_cap, max: max_cap
-            # ?? max_cap < base_cap??鍮꾩젙???곗씠??諛⑹뼱
+            # 단 max_cap < base_cap인 비정상 데이터 방어
             real_max = max(max_cap, base_cap)
             return [base_cap, real_max]
             
-        # 3. 異붽? ?붽툑 ?녿뒗 寃쎌슦 (湲곕낯)
+        # 3. 추가 요금 없는 경우 (기본)
         # min: rec_cap, max: rec_cap + 2
-        # ?? max_cap???섏? ?딅룄濡??쒗븳
+        # 단 max_cap을 넘지 않도록 제한
         min_c = rec_cap
         max_c = min(rec_cap + 2, max_cap)
         
-        # 留뚯빟 rec_cap + 2 > max_cap ?대씪??max_c媛 min_c蹂대떎 ?묒븘吏??寃쎌슦 諛⑹뼱
-        # (?? rec=5, max=5 -> min=5, max=5)
+        # 만약 rec_cap + 2 > max_cap 이라면 max_c가 min_c보다 작아지는 경우 방어
+        # (예: rec=5, max=5 -> min=5, max=5)
         max_c = max(max_c, min_c)
         
         return [min_c, max_c]
@@ -386,48 +386,48 @@ class RoomCollectionService:
 
         # If there are unresolved items, export them
         if unresolved_items:
-            # ?섍꼍蹂?섎줈 寃쎈줈 ?ㅼ젙 媛?? 湲곕낯媛믪? ?꾨줈?앺듃 猷⑦듃/scripts/unresolved
-            default_dir = Path(__file__).parent.parent.parent / "scripts" / "unresolved"
-            export_dir = Path(os.getenv("UNRESOLVED_EXPORT_DIR", str(default_dir)))
-            export_dir.mkdir(parents=True, exist_ok=True)
+                # 로컬 환경에서 호출 시 경로 설정 가능. 기본값은 프로젝트 루트/scripts/unresolved
+                default_dir = Path(__file__).parent.parent.parent / "scripts" / "unresolved"
+                export_dir = Path(os.getenv("UNRESOLVED_EXPORT_DIR", str(default_dir)))
+                export_dir.mkdir(parents=True, exist_ok=True)
 
-            # Generate filename with current date
-            date_str = datetime.now().strftime("%Y%m%d")
-            export_file = export_dir / f"unresolved_{date_str}.json"
+                # Generate filename with current date
+                date_str = datetime.now().strftime("%Y%m%d")
+                export_file = export_dir / f"unresolved_{date_str}.json"
 
-            # Load existing data if file exists, otherwise start with empty list
-            existing_data = []
-            if export_file.exists():
-                try:
-                    with open(export_file, "r", encoding="utf-8") as f:
-                        existing_data = json.load(f)
-                except Exception as e:
-                    logger.warning(f"Failed to read existing unresolved file: {e}")
+                # Load existing data if file exists, otherwise start with empty list
+                existing_data = []
+                if export_file.exists():
+                    try:
+                        with open(export_file, "r", encoding="utf-8") as f:
+                            existing_data = json.load(f)
+                    except Exception as e:
+                        logger.warning(f"Failed to read existing unresolved file: {e}")
 
-            # Append new unresolved items with duplicate check
-            existing_ids = {item["biz_item_id"] for item in existing_data}
-            new_items = [item for item in unresolved_items if item["biz_item_id"] not in existing_ids]
+                # Append new unresolved items with duplicate check
+                existing_ids = {item["biz_item_id"] for item in existing_data}
+                new_items = [item for item in unresolved_items if item["biz_item_id"] not in existing_ids]
 
-            if new_items:
-                existing_data.extend(new_items)
+                if new_items:
+                    existing_data.extend(new_items)
 
-                # Atomic write: temp file ??rename?쇰줈 以묎컙 ?곹깭 諛⑹?
-                tmp_fd, tmp_path = tempfile.mkstemp(
-                    dir=str(export_dir), suffix=".tmp"
-                )
-                try:
-                    with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
-                        json.dump(existing_data, f, ensure_ascii=False, indent=2)
-                    # os.replace???먯옄??(媛숈? ?뚯씪?쒖뒪????
-                    os.replace(tmp_path, str(export_file))
-                except Exception:
-                    # ?ㅽ뙣 ???꾩떆 ?뚯씪 ?뺣━
-                    if os.path.exists(tmp_path):
-                        os.unlink(tmp_path)
-                    raise
+                    # Atomic write: temp file 후 rename으로 중간 상태 방지
+                    tmp_fd, tmp_path = tempfile.mkstemp(
+                        dir=str(export_dir), suffix=".tmp"
+                    )
+                    try:
+                        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                            json.dump(existing_data, f, ensure_ascii=False, indent=2)
+                        # os.replace는 원자적(같은 파일시스템 상)
+                        os.replace(tmp_path, str(export_file))
+                    except Exception:
+                        # 실패 시 임시 파일 정리
+                        if os.path.exists(tmp_path):
+                            os.unlink(tmp_path)
+                        raise
 
-                logger.info(f"Exported {len(new_items)} new unresolved items to {export_file} (skipped {len(unresolved_items) - len(new_items)} duplicates)")
-            else:
-                logger.debug(f"All {len(unresolved_items)} items were already in unresolved list. Skipping export.")
+                    logger.info(f"Exported {len(new_items)} new unresolved items to {export_file} (skipped {len(unresolved_items) - len(new_items)} duplicates)")
+                else:
+                    logger.debug(f"All {len(unresolved_items)} items were already in unresolved list. Skipping export.")
 
 


### PR DESCRIPTION
## 0. 도입 배경 (Background)
일부 오픈소스 기여 환경 또는 텍스트 에디터 설정 차이로 인해 일부 서비스 레이어 파일에서 한글 인코딩이 깨지는 현상(모지바케)이 발생했습니다. 특히 클라이언트에 반환될 수 있는 예외 메시지가 깨져서 노출될 경우 서비스 신뢰도에 영향을 줄 수 있어, 이를 정상화하고 전체 팀원이 동일한 인코딩 설정을 공유할 수 있도록 설정 파일을 추가했습니다.

## 1. 주요 변경 사항 (Proposed Changes)
- 한글 주석 및 문자열 복구:
  - availability_service.py : 깨진 Docstring, 인라인 주석, 그리고 사용자에게 노출되는 ValueError 메시지를 문맥에 맞게 정상 한국어로 복구하여 데이터 오염을 해결했습니다.
  - room_collection_service.py: LLM 파싱 및 데이터 수집 로직 설명에 포함된 Rationale 섹션의 깨진 텍스트를 복원했습니다.

- .editorconfig 규격 도입: 프로젝트 루트에 설정 파일을 추가하여 모든 개발 환경에서 UTF-8 인코딩과 LF 개행 문자가 강제되도록 조치했습니다. 이를 통해 향후 재발 가능성을 원천 차단했습니다.

## 2. 체크리스트 (Checklist)
 관련된 이슈를 PR 커밋 메시지 또는 본문에 링크했습니다. (#185)
 PR 제목은 [#이슈번호]; <태그>: <설명> 컨벤션을 준수했습니다.
 새로 작성된 함수와 클래스에는 Google Style Docstring(의도, 파라미터 등)이 포함되어 있습니다.
 테스트 코드가 작성되었거나 기능 테스트가 완료되었습니다. (pytest 통과 확인)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error feedback for invalid time-slot submissions with clearer client-facing messages
  * Hardened capacity calculations with stronger validation, clamping, and safeguards to prevent unrealistic ranges

* **Documentation**
  * Clarified internal comments and docstrings to English for improved readability

* **Chores**
  * Added an editor configuration to standardize formatting and whitespace rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->