### PR TITLE
[#187]; chore: 크롤러 필수 환경변수 누락 시의 경고 로깅 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ SUPABASE_KEY=your_anon_key_here
 SUPABASE_TABLE=v_full_info             # 또는 변경된 테이블명
 
 # ==== Crawler Configuration ====
+# NOTE: 아래 4가지 환경변수는 예약 시스템 자동화(크롤링 기능) 사용 시 반드시 필요한 조건부 필수 변수입니다.
+# 미설정 시 관련 기능 수행 시 빈 결과를 반환하며 앱 시작 시 경고(Warning) 로그가 출력됩니다.
+GROOVE_BASE_URL=http://example-groove-url.com
+DREAM_BASE_URL=http://example-dream-url.com
+LOGIN_ID=your_crawler_login_id
+LOGIN_PW=your_crawler_login_password
 CRAWLER_PAGE_WAIT_MS=3000              # 페이지 로딩 대기 시간 (ms)
 CRAWLER_SCROLL_WAIT_MS=1500            # 스크롤 후 대기 시간 (ms)
 CRAWLER_MAX_PAGES=5                    # 최대 페이지네이션 수

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,7 +1,10 @@
 import os
+import logging
 from dotenv import load_dotenv
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 APP_ENV = os.getenv("APP_ENV", "production")
 IS_DEBUG = APP_ENV == "development"
@@ -34,6 +37,22 @@ RATE_LIMIT_PER_MINUTE = int(os.getenv("RATE_LIMIT_PER_MINUTE", "5"))
 
 if not SUPABASE_URL or not SUPABASE_KEY:
     raise ValueError("SUPABASE_URL과 SUPABASE_KEY 환경변수가 필요합니다.")
+
+missing_crawler_vars = []
+if not GROOVE_BASE_URL:
+    missing_crawler_vars.append("GROOVE_BASE_URL")
+if not DREAM_BASE_URL:
+    missing_crawler_vars.append("DREAM_BASE_URL")
+if not LOGIN_ID:
+    missing_crawler_vars.append("LOGIN_ID")
+if not LOGIN_PW:
+    missing_crawler_vars.append("LOGIN_PW")
+
+if missing_crawler_vars:
+    logger.warning(
+        f"필수 크롤러 환경변수가 누락되었습니다: {', '.join(missing_crawler_vars)}. "
+        f"환경변수 누락 시 크롤링 기능이 비정상적으로 빈 결과를 반환할 수 있습니다."
+    )
 
 
 # CORS 허용 오리진 (환경변수 기반)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -18,22 +18,7 @@ DREAM_BASE_URL = os.getenv("DREAM_BASE_URL")
 SUPABASE_URL = os.getenv("SUPABASE_URL")
 SUPABASE_KEY = os.getenv("SUPABASE_KEY")
 
-GROOVE_LOGIN_URL = f"{GROOVE_BASE_URL}/member/login_exec.asp"
-GROOVE_RESERVE_URL = f"{GROOVE_BASE_URL}/reservation/reserve_table_view.asp"
-GROOVE_RESERVE_URL1 = f"{GROOVE_BASE_URL}/reservation/reserve.asp"
-
-DREAM_LOGIN_URL = f"{DREAM_BASE_URL}/bbs/login_check.php"  # 드림 합주실 실제 로그인 URL
-DREAM_HEADERS = {
-    "User-Agent": "Mozilla/5.0",
-    "Content-Type": "application/x-www-form-urlencoded",
-}
-
-CORS_ORIGIN_REGEX = os.getenv("CORS_ORIGIN_REGEX")
-
-
-SUPABASE_TABLE = os.getenv("SUPABASE_TABLE", "v_full_info")
-
-RATE_LIMIT_PER_MINUTE = int(os.getenv("RATE_LIMIT_PER_MINUTE", "5"))
+# --- 필수 환경변수 검증 (URL 파생 변수 생성 이전에 수행) ---
 
 if not SUPABASE_URL or not SUPABASE_KEY:
     raise ValueError("SUPABASE_URL과 SUPABASE_KEY 환경변수가 필요합니다.")
@@ -53,6 +38,27 @@ if missing_crawler_vars:
         f"필수 크롤러 환경변수가 누락되었습니다: {', '.join(missing_crawler_vars)}. "
         f"환경변수 누락 시 크롤링 기능이 비정상적으로 빈 결과를 반환할 수 있습니다."
     )
+
+# --- URL 파생 변수 (None 안전 처리) ---
+# NOTE: BASE_URL이 None이면 깨진 URL("None/...")이 생성되는 것을 방지하기 위해
+# 조건부로 생성하며, None인 경우 크롤러 호출 시점에서 별도 예외 처리됨.
+
+GROOVE_LOGIN_URL = f"{GROOVE_BASE_URL}/member/login_exec.asp" if GROOVE_BASE_URL else None
+GROOVE_RESERVE_URL = f"{GROOVE_BASE_URL}/reservation/reserve_table_view.asp" if GROOVE_BASE_URL else None
+GROOVE_RESERVE_URL1 = f"{GROOVE_BASE_URL}/reservation/reserve.asp" if GROOVE_BASE_URL else None
+
+DREAM_LOGIN_URL = f"{DREAM_BASE_URL}/bbs/login_check.php" if DREAM_BASE_URL else None  # 드림 합주실 실제 로그인 URL
+DREAM_HEADERS = {
+    "User-Agent": "Mozilla/5.0",
+    "Content-Type": "application/x-www-form-urlencoded",
+}
+
+CORS_ORIGIN_REGEX = os.getenv("CORS_ORIGIN_REGEX")
+
+
+SUPABASE_TABLE = os.getenv("SUPABASE_TABLE", "v_full_info")
+
+RATE_LIMIT_PER_MINUTE = int(os.getenv("RATE_LIMIT_PER_MINUTE", "5"))
 
 
 # CORS 허용 오리진 (환경변수 기반)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -23,21 +23,35 @@ SUPABASE_KEY = os.getenv("SUPABASE_KEY")
 if not SUPABASE_URL or not SUPABASE_KEY:
     raise ValueError("SUPABASE_URL과 SUPABASE_KEY 환경변수가 필요합니다.")
 
-missing_crawler_vars = []
+# NOTE: config.py는 setup_logging() 이전에 임포트되므로,
+# 이 시점에서 logger.warning()을 호출하면 Python 기본 lastResort 핸들러로 출력됨.
+# 따라서 누락 변수 리스트만 저장하고, 경고 출력은 setup_logging() 이후에 호출하도록 지연 처리.
+_MISSING_CRAWLER_VARS: list[str] = []
 if not GROOVE_BASE_URL:
-    missing_crawler_vars.append("GROOVE_BASE_URL")
+    _MISSING_CRAWLER_VARS.append("GROOVE_BASE_URL")
 if not DREAM_BASE_URL:
-    missing_crawler_vars.append("DREAM_BASE_URL")
+    _MISSING_CRAWLER_VARS.append("DREAM_BASE_URL")
 if not LOGIN_ID:
-    missing_crawler_vars.append("LOGIN_ID")
+    _MISSING_CRAWLER_VARS.append("LOGIN_ID")
 if not LOGIN_PW:
-    missing_crawler_vars.append("LOGIN_PW")
+    _MISSING_CRAWLER_VARS.append("LOGIN_PW")
 
-if missing_crawler_vars:
-    logger.warning(
-        f"필수 크롤러 환경변수가 누락되었습니다: {', '.join(missing_crawler_vars)}. "
-        f"환경변수 누락 시 크롤링 기능이 비정상적으로 빈 결과를 반환할 수 있습니다."
-    )
+
+def emit_startup_warnings() -> None:
+    """setup_logging() 이후에 호출하여 정규 로그 포맷으로 환경변수 누락 경고를 출력합니다.
+
+    Rationale:
+        config.py는 모듈 임포트 시 즉시 실행되므로, 로깅 설정(핸들러, 포맷터)이
+        완료되기 전에 logger.warning()을 호출하면 Python 기본 포맷으로 출력됩니다.
+        이를 방지하기 위해 누락 정보를 저장해두었다가 setup_logging() 직후에
+        본 함수를 호출하여 JSON 포맷 등 정규 로깅 파이프라인을 통해 경고합니다.
+    """
+    if _MISSING_CRAWLER_VARS:
+        logger.warning(
+            "필수 크롤러 환경변수가 누락되었습니다: %s. "
+            "환경변수 누락 시 크롤링 기능이 비정상적으로 빈 결과를 반환할 수 있습니다.",
+            ", ".join(_MISSING_CRAWLER_VARS)
+        )
 
 # --- URL 파생 변수 (None 안전 처리) ---
 # NOTE: BASE_URL이 None이면 깨진 URL("None/...")이 생성되는 것을 방지하기 위해

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -37,6 +37,8 @@ if not LOGIN_PW:
     _MISSING_CRAWLER_VARS.append("LOGIN_PW")
 
 
+_WARNINGS_EMITTED = False
+
 def emit_startup_warnings() -> None:
     """setup_logging() 이후에 호출하여 정규 로그 포맷으로 환경변수 누락 경고를 출력합니다.
 
@@ -46,6 +48,11 @@ def emit_startup_warnings() -> None:
         이를 방지하기 위해 누락 정보를 저장해두었다가 setup_logging() 직후에
         본 함수를 호출하여 JSON 포맷 등 정규 로깅 파이프라인을 통해 경고합니다.
     """
+    global _WARNINGS_EMITTED
+    if _WARNINGS_EMITTED:
+        return
+    _WARNINGS_EMITTED = True
+
     if _MISSING_CRAWLER_VARS:
         logger.warning(
             "필수 크롤러 환경변수가 누락되었습니다: %s. "

--- a/app/main.py
+++ b/app/main.py
@@ -116,5 +116,11 @@ app.add_exception_handler(Exception, global_exception_handler_envelope)
 # 로깅 설정(콘솔 + 일자별 파일 로테이션, JSON 포맷)
 setup_logging()
 
+# NOTE: config.py는 모듈 임포트 시점에 실행되어 setup_logging() 이전에 로드됨.
+# 따라서 환경변수 누락 경고를 정규 로그 포맷(JSON)으로 출력하기 위해
+# setup_logging() 직후에 지연 호출합니다.
+from app.core.config import emit_startup_warnings
+emit_startup_warnings()
+
 if __name__ == "__main__":
     uvicorn.run("main:app", port=8000, reload=True)

--- a/app/main.py
+++ b/app/main.py
@@ -30,7 +30,7 @@ from app.exception.envelope_handlers import (
 from app.utils.client_loader import close_global_client, set_global_client
 from pydantic import ValidationError
 import httpx
-from app.core.config import SUPABASE_URL, SUPABASE_KEY, HEALTH_CHECK_TIMEOUT, SUPABASE_TABLE
+from app.core.config import SUPABASE_URL, SUPABASE_KEY, HEALTH_CHECK_TIMEOUT, SUPABASE_TABLE, emit_startup_warnings
 from app.models.dto import HealthResponse
 
 @asynccontextmanager
@@ -166,7 +166,6 @@ setup_logging()
 # NOTE: config.py는 모듈 임포트 시점에 실행되어 setup_logging() 이전에 로드됨.
 # 따라서 환경변수 누락 경고를 정규 로그 포맷(JSON)으로 출력하기 위해
 # setup_logging() 직후에 지연 호출합니다.
-from app.core.config import emit_startup_warnings
 emit_startup_warnings()
 
 if __name__ == "__main__":

--- a/app/utils/login.py
+++ b/app/utils/login.py
@@ -7,6 +7,8 @@ class LoginManager:
     """로그인 전담 매니저"""
     @staticmethod
     async def login(client: httpx.AsyncClient):
+        if not GROOVE_BASE_URL:
+            raise GrooveCredentialError("환경변수 GROOVE_BASE_URL 설정 필요")
         if not LOGIN_ID or not LOGIN_PW:
             raise GrooveCredentialError("환경변수 LOGIN_ID/LOGIN_PW 설정 필요")
         url = f"{GROOVE_BASE_URL}/member/login_exec.asp"

--- a/app/utils/login.py
+++ b/app/utils/login.py
@@ -1,5 +1,5 @@
 import httpx
-from app.core.config import GROOVE_BASE_URL, LOGIN_ID, LOGIN_PW, GROOVE_LOGIN_URL
+from app.core.config import LOGIN_ID, LOGIN_PW, GROOVE_LOGIN_URL
 from app.exception.crawler.groove_exception import GrooveCredentialError, GrooveLoginError
 
 
@@ -7,11 +7,11 @@ class LoginManager:
     """로그인 전담 매니저"""
     @staticmethod
     async def login(client: httpx.AsyncClient):
-        if not GROOVE_BASE_URL:
+        if not GROOVE_LOGIN_URL:
             raise GrooveCredentialError("환경변수 GROOVE_BASE_URL 설정 필요")
         if not LOGIN_ID or not LOGIN_PW:
             raise GrooveCredentialError("환경변수 LOGIN_ID/LOGIN_PW 설정 필요")
-        url = f"{GROOVE_BASE_URL}/member/login_exec.asp"
+        url = GROOVE_LOGIN_URL
         response = await client.post(
             url,
             data={"login_id": LOGIN_ID, "login_pw": LOGIN_PW},

--- a/tests/api/test_favorites.py
+++ b/tests/api/test_favorites.py
@@ -3,6 +3,7 @@ from fastapi.testclient import TestClient
 from app.main import app
 from app.api.dependencies import get_favorite_repository
 from app.repositories.memory import MockFavoriteRepository
+from app.api.favorites import MAX_FAVORITES_PER_DEVICE
 
 @pytest.fixture
 def mock_repo():
@@ -66,7 +67,6 @@ def test_add_favorite_idempotency(client, api_endpoint, headers, target_business
 
 def test_add_favorite_limit_exceeded(client, headers, target_business_id, mock_repo):
     """최대 즐겨찾기 개수를 초과하면 400 에러를 반환해야 한다."""
-    from app.api.favorites import MAX_FAVORITES_PER_DEVICE
     
     # Arrange: 한도를 가득 채움
     for i in range(MAX_FAVORITES_PER_DEVICE):

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -1,0 +1,68 @@
+import logging
+from unittest.mock import patch
+import pytest
+
+from app.core import config
+
+@pytest.fixture
+def reset_warnings_emitted():
+    """테스트 전후로 _WARNINGS_EMITTED 플래그를 초기화하는 픽스처"""
+    original_state = config._WARNINGS_EMITTED
+    config._WARNINGS_EMITTED = False
+    yield
+    config._WARNINGS_EMITTED = original_state
+
+class TestStartupWarnings:
+    """emit_startup_warnings() 함수에 대한 격리된 단위 테스트"""
+
+    @patch("app.core.config._MISSING_CRAWLER_VARS", new_callable=list)
+    def test_emit_warnings_all_missing(self, mock_missing_vars, caplog, reset_warnings_emitted):
+        """모든 4개 변수 누락 시 모두 경고에 나타나는지 검증"""
+        mock_missing_vars.extend(["GROOVE_BASE_URL", "DREAM_BASE_URL", "LOGIN_ID", "LOGIN_PW"])
+        
+        with caplog.at_level(logging.WARNING):
+            config.emit_startup_warnings()
+            
+        assert len(caplog.records) == 1
+        warning_msg = caplog.records[0].getMessage()
+        assert "GROOVE_BASE_URL" in warning_msg
+        assert "DREAM_BASE_URL" in warning_msg
+        assert "LOGIN_ID" in warning_msg
+        assert "LOGIN_PW" in warning_msg
+
+    @patch("app.core.config._MISSING_CRAWLER_VARS", new_callable=list)
+    def test_emit_warnings_some_missing(self, mock_missing_vars, caplog, reset_warnings_emitted):
+        """일부 변수만 누락 시 해당 변수만 경고에 나타나는지 검증"""
+        mock_missing_vars.extend(["GROOVE_BASE_URL"])
+        
+        with caplog.at_level(logging.WARNING):
+            config.emit_startup_warnings()
+            
+        assert len(caplog.records) == 1
+        warning_msg = caplog.records[0].getMessage()
+        assert "GROOVE_BASE_URL" in warning_msg
+        assert "DREAM_BASE_URL" not in warning_msg
+
+    @patch("app.core.config._MISSING_CRAWLER_VARS", new_callable=list)
+    def test_emit_warnings_none_missing(self, mock_missing_vars, caplog, reset_warnings_emitted):
+        """모든 변수 설정(누락 없음) 시 경고가 출력되지 않는지 검증"""
+        mock_missing_vars.clear()
+        
+        with caplog.at_level(logging.WARNING):
+            config.emit_startup_warnings()
+            
+        assert len(caplog.records) == 0
+
+    @patch("app.core.config._MISSING_CRAWLER_VARS", new_callable=list)
+    def test_emit_warnings_idempotency(self, mock_missing_vars, caplog, reset_warnings_emitted):
+        """emit_startup_warnings() 중복 호출 시 경고가 한 번만 출력되는지 검증"""
+        mock_missing_vars.append("LOGIN_ID")
+        
+        with caplog.at_level(logging.WARNING):
+            # 두 번 호출
+            config.emit_startup_warnings()
+            config.emit_startup_warnings()
+            
+        # 레코드는 1개만 있어야 함 (멱등성 가드 검증)
+        assert len(caplog.records) == 1
+


### PR DESCRIPTION
<!-- 이슈번호를 작성해주세요 -->
Closes #187 

## 0. 도입 배경 (Background)
현재 `SUPABASE_URL`과 `SUPABASE_KEY`만 초기 검증을 거치고 있어, `GROOVE_BASE_URL`이나 `LOGIN_ID`와 같은 크롤러 필수 환경변수가 누락되어도 서버는 불만 없이 정상 기동됩니다.
이로 인해 배포 시 환경 설정이 누락되더라도 에러 로그 없이 크롤링 결과만 빈 값으로 반환되는 '침묵 실패(Silent Failure)'가 발생하여, 원인 파악 및 트러블슈팅에 오랜 시간이 소요되는 문제를 개선하고자 합니다.

## 1. 주요 변경 사항 (Proposed Changes)
- [app/core/config.py]에 필수 크롤러 환경변수(`GROOVE_BASE_URL`, `DREAM_BASE_URL`, `LOGIN_ID`, `LOGIN_PW`) 누락 검증 로직 추가.
- 환경변수 누락 시 **서버 기동을 멈추지는 않되**, 애플리케이션 시작 단계(`.env` 바인딩 시점)에서 구체적이고 명확한 `logging.warning` 알림을 1회성으로 출력하도록 변경.
- 이를 통해 모니터링 시 배포 초기 로그를 통해 즉각적으로 설정 누락 사실 및 빈 결과 반환 가능성을 인지할 수 있도록 조치.

## 2. 체크리스트 (Checklist)
- [x] 관련된 이슈를 PR 커밋 메시지 또는 본문에 링크했습니다. (`#187`)
- [x] PR 제목은 `[#이슈번호]; <태그>: <설명>` 컨벤션을 준수했습니다.
- [x] 새로 작성된 함수와 클래스에는 `Google Style Docstring`(의도, 파라미터 등)이 포함되어 있습니다. (해당 없음 / 로깅 로직에 적용됨)
- [x] 테스트 코드가 작성되었거나 기능 테스트가 완료되었습니다.

## 3. 참고 자료 (Optional)
- 누락 경고 로그 예시:
  `WARNING:app.core.config:필수 크롤러 환경변수가 누락되었습니다: GROOVE_BASE_URL, LOGIN_ID. 환경변수 누락 시 크롤링 기능이 비정상적으로 빈 결과를 반환할 수 있습니다.`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added optional crawler automation configuration through new environment variables for service integration.

**Improvements**
- Startup warnings now alert users when crawler credentials are missing, preventing silent failures and empty results.
- Enhanced error handling for missing required database credentials with clearer error messages.

**Tests**
- Added comprehensive test coverage for configuration validation and startup warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->