### PR TITLE
[#194]; bug: "당일" 심야 예약(23:00~01:00) 검증 오류 수정

### DIFF
--- a/app/validate/hour_validator.py
+++ b/app/validate/hour_validator.py
@@ -78,8 +78,10 @@ def validate_hour_slots(hour_slots: List[str], date: str):
     for slot in hour_slots:
         validate_hour_slot_format(slot)
         if input_date == today:
+            # NOTE: 24:00(end-of-day 마커)은 _slot_to_minutes 상 1440분으로 OVERNIGHT_EARLY_END_MINUTES(300)보다 크므로
+            #       overnight이어도 skip 대상이 아닙니다. 이는 의도된 동작입니다.
             if is_overnight and _slot_to_minutes(slot) <= OVERNIGHT_EARLY_END_MINUTES:
-                continue  # 다음날 새벽 슬롯은 과거 비교 제외
+                continue  # 다음날 새벽 슬롯(00:00~05:00)은 과거 비교 제외
             validate_hour_slot_not_past(slot, now.time())
 
     validate_hour_continuous(hour_slots, date)

--- a/app/validate/hour_validator.py
+++ b/app/validate/hour_validator.py
@@ -44,9 +44,22 @@ def validate_hour_slots(hour_slots: List[str], date: str):
     today = now.date()
     input_date = datetime.strptime(date, "%Y-%m-%d").date()
 
+    is_overnight = False
+    if input_date == today:
+        raw_minutes = [_slot_to_minutes(s) for s in hour_slots if re.match(HOUR_PATTERN, s)]
+        has_late_night = any(m >= 1140 for m in raw_minutes)   # 19:00 이후
+        has_early_morning = any(m <= 300 for m in raw_minutes)  # 05:00 이전
+        # Rationale: 23:00~01:00처럼 자정을 넘기는 overnight 예약에서
+        #            00:00, 01:00 등 새벽 슬롯은 실제로 "다음날" 시간임.
+        #            today 기준 과거 시간 비교를 적용하면 오탐이 발생하므로 스킵함.
+        #            validate_hour_continuous와 동일한 19:00/05:00 기준을 사용.
+        is_overnight = has_late_night and has_early_morning
+
     for slot in hour_slots:
         validate_hour_slot_format(slot)
         if input_date == today:
+            if is_overnight and _slot_to_minutes(slot) <= 300:
+                continue  # 다음날 새벽 슬롯은 과거 비교 제외
             validate_hour_slot_not_past(slot, now.time())
 
     validate_hour_continuous(hour_slots, date)

--- a/app/validate/hour_validator.py
+++ b/app/validate/hour_validator.py
@@ -10,6 +10,29 @@ from app.exception.common.hour_exception import (
 
 HOUR_PATTERN = r"^(?:[01]\d|2[0-4]):00$"
 
+# Overnight 판별 기준: 심야(19:00 이후) + 새벽(05:00 이전) 슬롯이 공존하면 자정 교차 예약
+# Rationale: validate_hour_slots/validate_hour_continuous 양쪽에서 동일한 기준을 공유하기 위해 상수화.
+#            한쪽만 바꾸는 silent 불일치를 방지함.
+OVERNIGHT_LATE_START_MINUTES = 19 * 60   # 19:00 = 1140분
+OVERNIGHT_EARLY_END_MINUTES = 5 * 60     # 05:00 = 300분
+
+def _is_overnight(minutes: List[int]) -> bool:
+    """19:00 이후와 05:00 이전 슬롯이 공존하면 overnight으로 판별합니다.
+
+    Args:
+        minutes (List[int]): 분 단위로 변환된 슬롯 정수 리스트.
+
+    Returns:
+        bool: True이면 자정을 교차하는(Overnight) 예약.
+
+    Rationale:
+        OVERNIGHT_LATE_START_MINUTES/OVERNIGHT_EARLY_END_MINUTES 상수를 사용하여
+        validate_hour_slots와 validate_hour_continuous가 동일한 기준으로 동작하도록 보장.
+    """
+    has_late_night = any(m >= OVERNIGHT_LATE_START_MINUTES for m in minutes)
+    has_early_morning = any(m <= OVERNIGHT_EARLY_END_MINUTES for m in minutes)
+    return has_late_night and has_early_morning
+
 
 def validate_hour_slot_format(slot: str):
     """시간 형식(HH:MM) 검증"""
@@ -47,18 +70,15 @@ def validate_hour_slots(hour_slots: List[str], date: str):
     is_overnight = False
     if input_date == today:
         raw_minutes = [_slot_to_minutes(s) for s in hour_slots if re.match(HOUR_PATTERN, s)]
-        has_late_night = any(m >= 1140 for m in raw_minutes)   # 19:00 이후
-        has_early_morning = any(m <= 300 for m in raw_minutes)  # 05:00 이전
+        is_overnight = _is_overnight(raw_minutes)
         # Rationale: 23:00~01:00처럼 자정을 넘기는 overnight 예약에서
         #            00:00, 01:00 등 새벽 슬롯은 실제로 "다음날" 시간임.
         #            today 기준 과거 시간 비교를 적용하면 오탐이 발생하므로 스킵함.
-        #            validate_hour_continuous와 동일한 19:00/05:00 기준을 사용.
-        is_overnight = has_late_night and has_early_morning
 
     for slot in hour_slots:
         validate_hour_slot_format(slot)
         if input_date == today:
-            if is_overnight and _slot_to_minutes(slot) <= 300:
+            if is_overnight and _slot_to_minutes(slot) <= OVERNIGHT_EARLY_END_MINUTES:
                 continue  # 다음날 새벽 슬롯은 과거 비교 제외
             validate_hour_slot_not_past(slot, now.time())
 
@@ -94,14 +114,13 @@ def validate_hour_continuous(hour_slots: List[str], date: str):
     # 가장 극단적인 심야 예약 조합은 "19:00 ~ 00:00(24:00)"에서 시작해, 가장 늦게 끝나는 조합이 "00:00 ~ 05:00"입니다.
     # 즉, 정상적인 5시간 이내의 예약이라면 '19:00 이전' 시간대와 '05:00 이후' 시간대가 같은 슬롯 배열에 공존할 수 없습니다.
     # 따라서 19:00(1140분) 이후 값을 "심야", 05:00(300분) 이전 값을 "새벽"으로 정의하여 교차 여부를 판별합니다.
-    has_late_night = any(s >= 1140 for s in raw_slots)   # 19:00 이후 슬롯 존재 여부
-    has_early_morning = any(s <= 300 for s in raw_slots) # 05:00 이전 슬롯 존재 여부
+    has_overnight = _is_overnight(raw_slots)
     
     # 심야(19:00~)와 새벽(~05:00) 시간대가 배열에 공존한다면 자정을 넘긴(Overnight) 예약입니다.
     # 00:00~04:00과 같은 새벽 슬롯들은 숫자가 작아 정렬 시 앞으로 오게 되므로 시계열 연속성이 깨집니다.
     # 이를 방지하기 위해 새벽 시간대값에 하루치인 1440분을 더해 익일 시간(예: 01:00 -> 25:00)으로 변환 후 정렬합니다.
-    if has_late_night and has_early_morning:
-        slots = sorted((s + 1440 if s <= 300 else s) for s in raw_slots)
+    if has_overnight:
+        slots = sorted((s + 1440 if s <= OVERNIGHT_EARLY_END_MINUTES else s) for s in raw_slots)
     else:
         slots = sorted(raw_slots)
 

--- a/app/validate/hour_validator.py
+++ b/app/validate/hour_validator.py
@@ -1,6 +1,15 @@
 ﻿import re
-from datetime import datetime
+from datetime import datetime, timezone, timedelta
 from typing import List
+try:
+    from zoneinfo import ZoneInfo
+    # NOTE: Windows에서는 tzdata 패키지가 없으면 ZoneInfoNotFoundError 발생.
+    #       프로덕션 환경에선 `pip install tzdata`로 반드시 설치해야 함.
+    KST = ZoneInfo("Asia/Seoul")
+except Exception:
+    # HACK: tzdata 미설치 환경(Windows 로컬 등)에서의 fallback.
+    #       ZoneInfo를 사용할 수 없을 때 UTC+9 오프셋으로 대체.
+    KST = timezone(timedelta(hours=9))
 
 from app.exception.common.hour_exception import (
     HourDiscontinuousError,
@@ -9,6 +18,9 @@ from app.exception.common.hour_exception import (
 )
 
 HOUR_PATTERN = r"^(?:[01]\d|2[0-4]):00$"
+
+# NOTE: 운영 환경의 타임존 설정 오류가 전체 시간 검증을 무력화하는 것을 방지하기 위해
+#       서버 로컬 타임존 대신 KST를 명시적으로 고정함. (import 블록에서 선언)
 
 # Overnight 판별 기준: 심야(19:00 이상) + 새벽(04:00 이하) 슬롯이 공존하면 자정 교차 예약
 # Rationale: validate_hour_slots/validate_hour_continuous 양쪽에서 동일한 기준을 공유하기 위해 상수화.
@@ -27,10 +39,22 @@ def _is_overnight(minutes: List[int]) -> bool:
     Returns:
         bool: True이면 자정을 교차하는(Overnight) 예약.
 
+    Raises:
+        InvalidHourSlotError: 음수이거나 1440(24:00)을 초과하는 분 값이 포함된 경우.
+
     Rationale:
         OVERNIGHT_LATE_START_MINUTES/OVERNIGHT_EARLY_END_MINUTES 상수를 사용하여
         validate_hour_slots와 validate_hour_continuous가 동일한 기준으로 동작하도록 보장.
+        빈 리스트나 범위를 벗어난 값이 입력될 경우 False 반환 또는 예외를 발생시켜
+        False Positive로 인한 Silent failure를 방지함.
     """
+    if not minutes:
+        return False  # 빈 입력은 overnight 아님으로 명시적 처리
+
+    # 음수 또는 24:00(1440분) 초과 값은 _slot_to_minutes에서 생성될 수 없는 범위이므로 방어 처리
+    if any(m < 0 or m > 1440 for m in minutes):
+        raise InvalidHourSlotError("유효 범위(0~1440분)를 벗어난 분 값이 포함되어 있습니다.")
+
     has_late_night = any(m >= OVERNIGHT_LATE_START_MINUTES for m in minutes)
     has_early_morning = any(m <= OVERNIGHT_EARLY_END_MINUTES for m in minutes)
     return has_late_night and has_early_morning
@@ -65,7 +89,7 @@ def validate_hour_slot_not_past(slot: str, now_time):
 
 def validate_hour_slots(hour_slots: List[str], date: str):
     """시간 슬롯 전체 검증(형식 + 과거여부 + 연속성)"""
-    now = datetime.now()
+    now = datetime.now(KST)
     today = now.date()
     input_date = datetime.strptime(date, "%Y-%m-%d").date()
 
@@ -119,6 +143,8 @@ def validate_hour_continuous(hour_slots: List[str], date: str):
     raw_slots = [_slot_to_minutes(slot) for slot in hour_slots]
     
     # [자정을 넘기는 연속성 검사 기준 (19:00 ~ 04:00)]
+    # NOTE: 슬롯 최대 개수(5시간) 검증은 DTO 계층에서 수행됩니다.
+    #       이 함수는 DTO 유효성 검사를 통과한 입력만 받는다고 가정합니다.
     # DTO 계층에서 허용하는 최대 예약 시간은 5시간입니다.
     # 가장 극단적인 심야 예약 조합은 "19:00 ~ 00:00(24:00)" 시작, 가장 늦게 끝나는 조합이 "23:00 ~ 04:00"입니다.
     # 즉, 정상적인 5시간 이내의 예약이라면 '19:00 미만' 시간대와 '04:00 초과' 시간대가 같은 슬롯 배열에 공존할 수 없습니다.

--- a/app/validate/hour_validator.py
+++ b/app/validate/hour_validator.py
@@ -10,14 +10,16 @@ from app.exception.common.hour_exception import (
 
 HOUR_PATTERN = r"^(?:[01]\d|2[0-4]):00$"
 
-# Overnight 판별 기준: 심야(19:00 이후) + 새벽(05:00 이전) 슬롯이 공존하면 자정 교차 예약
+# Overnight 판별 기준: 심야(19:00 이상) + 새벽(04:00 이하) 슬롯이 공존하면 자정 교차 예약
 # Rationale: validate_hour_slots/validate_hour_continuous 양쪽에서 동일한 기준을 공유하기 위해 상수화.
 #            한쪽만 바꾸는 silent 불일치를 방지함.
 OVERNIGHT_LATE_START_MINUTES = 19 * 60   # 19:00 = 1140분
-OVERNIGHT_EARLY_END_MINUTES = 5 * 60     # 05:00 = 300분
+OVERNIGHT_EARLY_END_MINUTES = 4 * 60     # 04:00 = 240분 (포함, overnight 새벽 종료 기준)
+# NOTE: 최대 5시간 overnight 시 23:00 시작 → 04:00 종료가 최대.
+#       05:00은 19:00이상 슬롯과 5시간 내에 공존 불가 → overnight 콘텍스트에서 절대 등장 불가.
 
 def _is_overnight(minutes: List[int]) -> bool:
-    """19:00 이후와 05:00 이전 슬롯이 공존하면 overnight으로 판별합니다.
+    """19:00 이상과 04:00 이하 슬롯이 공존하면 overnight으로 판별합니다.
 
     Args:
         minutes (List[int]): 분 단위로 변환된 슬롯 정수 리스트.
@@ -67,21 +69,26 @@ def validate_hour_slots(hour_slots: List[str], date: str):
     today = now.date()
     input_date = datetime.strptime(date, "%Y-%m-%d").date()
 
-    is_overnight = False
-    if input_date == today:
-        raw_minutes = [_slot_to_minutes(s) for s in hour_slots if re.match(HOUR_PATTERN, s)]
-        is_overnight = _is_overnight(raw_minutes)
-        # Rationale: 23:00~01:00처럼 자정을 넘기는 overnight 예약에서
-        #            00:00, 01:00 등 새벽 슬롯은 실제로 "다음날" 시간임.
-        #            today 기준 과거 시간 비교를 적용하면 오탐이 발생하므로 스킵함.
-
+    # 1단계: 형식 검증 일괄 수행 (이후 _slot_to_minutes 재호출 방지)
     for slot in hour_slots:
         validate_hour_slot_format(slot)
+
+    # 2단계: 분 변환 결과를 overnight 판별과 과거 시간 검증 양쪽에서 공유 (이중 호출 제거)
+    slot_minutes = [_slot_to_minutes(s) for s in hour_slots]
+
+    # 3단계: overnight 판별 (오늘 예약인 경우에만 적용)
+    # Rationale: 23:00~01:00처럼 자정을 넘기는 overnight 예약에서
+    #            00:00, 01:00 등 새벽 슬롯은 실제로 "다음날" 시간임.
+    #            today 기준 과거 시간 비교를 적용하면 오탐이 발생하므로 overnight 슬롯은 스킵함.
+    is_overnight = _is_overnight(slot_minutes) if input_date == today else False
+
+    # 4단계: 과거 시간 검증
+    for slot, minutes in zip(hour_slots, slot_minutes):
         if input_date == today:
             # NOTE: 24:00(end-of-day 마커)은 _slot_to_minutes 상 1440분으로 OVERNIGHT_EARLY_END_MINUTES(300)보다 크므로
             #       overnight이어도 skip 대상이 아닙니다. 이는 의도된 동작입니다.
-            if is_overnight and _slot_to_minutes(slot) <= OVERNIGHT_EARLY_END_MINUTES:
-                continue  # 다음날 새벽 슬롯(00:00~05:00)은 과거 비교 제외
+            if is_overnight and minutes <= OVERNIGHT_EARLY_END_MINUTES:
+                continue  # overnight 새벽 슬롯(00:00~04:00)은 과거 비교 제외
             validate_hour_slot_not_past(slot, now.time())
 
     validate_hour_continuous(hour_slots, date)
@@ -111,16 +118,16 @@ def validate_hour_continuous(hour_slots: List[str], date: str):
 
     raw_slots = [_slot_to_minutes(slot) for slot in hour_slots]
     
-    # [자정을 넘기는 연속성 검사 기준 (19:00 ~ 05:00)]
+    # [자정을 넘기는 연속성 검사 기준 (19:00 ~ 04:00)]
     # DTO 계층에서 허용하는 최대 예약 시간은 5시간입니다.
-    # 가장 극단적인 심야 예약 조합은 "19:00 ~ 00:00(24:00)"에서 시작해, 가장 늦게 끝나는 조합이 "00:00 ~ 05:00"입니다.
-    # 즉, 정상적인 5시간 이내의 예약이라면 '19:00 이전' 시간대와 '05:00 이후' 시간대가 같은 슬롯 배열에 공존할 수 없습니다.
-    # 따라서 19:00(1140분) 이후 값을 "심야", 05:00(300분) 이전 값을 "새벽"으로 정의하여 교차 여부를 판별합니다.
+    # 가장 극단적인 심야 예약 조합은 "19:00 ~ 00:00(24:00)" 시작, 가장 늦게 끝나는 조합이 "23:00 ~ 04:00"입니다.
+    # 즉, 정상적인 5시간 이내의 예약이라면 '19:00 미만' 시간대와 '04:00 초과' 시간대가 같은 슬롯 배열에 공존할 수 없습니다.
+    # 따라서 19:00(1140분) 이상 값을 "심야", 04:00(240분) 이하 값을 "새벽"으로 정의하여 교차 여부를 판별합니다.
     has_overnight = _is_overnight(raw_slots)
     
-    # 심야(19:00~)와 새벽(~05:00) 시간대가 배열에 공존한다면 자정을 넘긴(Overnight) 예약입니다.
+    # 심야(19:00~)와 새벽(~04:00) 시간대가 배열에 공존한다면 자정을 넘긴(Overnight) 예약입니다.
     # 00:00~04:00과 같은 새벽 슬롯들은 숫자가 작아 정렬 시 앞으로 오게 되므로 시계열 연속성이 깨집니다.
-    # 이를 방지하기 위해 새벽 시간대값에 하루치인 1440분을 더해 익일 시간(예: 01:00 -> 25:00)으로 변환 후 정렬합니다.
+    # 이를 방지하기 위해 새벽 시간대값(04:00 이하)에 하루치인 1440분을 더해 익일 시간(예: 01:00 -> 25:00)으로 변환 후 정렬합니다.
     if has_overnight:
         slots = sorted((s + 1440 if s <= OVERNIGHT_EARLY_END_MINUTES else s) for s in raw_slots)
     else:

--- a/app/validate/hour_validator.py
+++ b/app/validate/hour_validator.py
@@ -23,8 +23,12 @@ HOUR_PATTERN = r"^(?:[01]\d|2[0-4]):00$"
 #       서버 로컬 타임존 대신 KST를 명시적으로 고정함. (import 블록에서 선언)
 
 # Overnight 판별 기준: 심야(19:00 이상) + 새벽(04:00 이하) 슬롯이 공존하면 자정 교차 예약
-# Rationale: validate_hour_slots/validate_hour_continuous 양쪽에서 동일한 기준을 공유하기 위해 상수화.
-#            한쪽만 바꾸는 silent 불일치를 방지함.
+# Rationale:
+#   validate_hour_slots/validate_hour_continuous 양쪽에서 동일한 기준을 공유하기 위해 상수화.
+#   한쪽만 바꾸는 silent 불일치를 방지함.
+#   DTO 최대 예약 시간(5시간)과 연동: 19:00 시작 → 00:00 종료(5시간), 00:00 시작 → 04:00 콜렉션(4시간, max)
+#   ⚠️ 향후 DTO 최대 예약 시간 변경 시 이 상수도 함께 조정해야 함.
+#   Reference: app/models/dto.py 내 hour_slots 길이 검증자
 OVERNIGHT_LATE_START_MINUTES = 19 * 60   # 19:00 = 1140분
 OVERNIGHT_EARLY_END_MINUTES = 4 * 60     # 04:00 = 240분 (포함, overnight 새벽 종료 기준)
 # NOTE: 최대 5시간 overnight 시 23:00 시작 → 04:00 종료가 최대.
@@ -109,7 +113,7 @@ def validate_hour_slots(hour_slots: List[str], date: str):
     # 4단계: 과거 시간 검증
     for slot, minutes in zip(hour_slots, slot_minutes):
         if input_date == today:
-            # NOTE: 24:00(end-of-day 마커)은 _slot_to_minutes 상 1440분으로 OVERNIGHT_EARLY_END_MINUTES(300)보다 크므로
+            # NOTE: 24:00(end-of-day 마커)은 _slot_to_minutes 상 1440분으로 OVERNIGHT_EARLY_END_MINUTES(240)보다 크므로
             #       overnight이어도 skip 대상이 아닙니다. 이는 의도된 동작입니다.
             if is_overnight and minutes <= OVERNIGHT_EARLY_END_MINUTES:
                 continue  # overnight 새벽 슬롯(00:00~04:00)은 과거 비교 제외

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ beautifulsoup4~=4.12
 pydantic~=2.7
 supabase~=2.4        # Supabase Python 클라이언트
 lxml~=5.2            # BeautifulSoup 'lxml' 파서
+tzdata~=2024.1       # Windows에서 zoneinfo(Asia/Seoul) 사용 시 필수
 
 # ==== 크롤러 & LLM ====
 playwright~=1.40     # Naver Map 크롤링

--- a/tests/exception/test_hour_validator.py
+++ b/tests/exception/test_hour_validator.py
@@ -161,17 +161,17 @@ class TestIsOvernightUnit:
     @pytest.mark.parametrize("minutes,expected", [
         # overnight O: 정확히 경계값 포함
         ([OVERNIGHT_LATE_START_MINUTES, 60], True),          # 19:00 + 01:00
-        ([OVERNIGHT_EARLY_END_MINUTES, 1200], True),         # 05:00 + 20:00
+        ([OVERNIGHT_EARLY_END_MINUTES, 1200], True),         # 새벽 경계(04:00)와 심야(20:00)가 공존 → overnight
         ([OVERNIGHT_LATE_START_MINUTES, OVERNIGHT_EARLY_END_MINUTES], True),  # 양쪽 경계
         ([1380, 60], True),                                  # 23:00 + 01:00
         # overnight X: 경계보다 1단위 미달/초과
         ([OVERNIGHT_LATE_START_MINUTES - 60, 60], False),    # 18:00(경계 미만) + 01:00
-        ([1200, OVERNIGHT_EARLY_END_MINUTES + 60], False),   # 20:00 + 06:00(경계 초과)
+        ([1200, OVERNIGHT_EARLY_END_MINUTES + 60], False),   # 20:00 + 05:00(경계 초과)
         ([1200, 480], False),                                # 20:00만 있고 새벽 없음
         ([60, OVERNIGHT_EARLY_END_MINUTES], False),          # 01:00만 있고 심야 없음
     ])
     def test_is_overnight_boundary(self, minutes, expected):
-        """_is_overnight()가 19:00/05:00 경계값을 포함(inclusive) 처리하는지 검증
+        """_is_overnight()가 19:00/04:00 경계값을 포함(inclusive) 처리하는지 검증
 
         Rationale:
             OVERNIGHT_LATE_START_MINUTES·OVERNIGHT_EARLY_END_MINUTES 상수를 >= / <= 로

--- a/tests/exception/test_hour_validator.py
+++ b/tests/exception/test_hour_validator.py
@@ -140,11 +140,13 @@ class TestOvernightValidation:
         ["19:00", "20:00", "21:00", "22:00", "23:00", "00:00"],
     ])
     def test_overnight_boundary_slots_are_not_rejected(self, slots):
-        """19:00·05:00 경계값이 포함된 연속 overnight 슬롯은 과거 판정 없이 통과해야 함
+        """OVERNIGHT_LATE_START_MINUTES(19:00) 경계값을 포함한 연속 overnight 슬롯은 과거 판정 없이 통과해야 함
 
         Rationale:
-            OVERNIGHT_LATE_START_MINUTES(19:00)·OVERNIGHT_EARLY_END_MINUTES(05:00) 상수를
-            직접 검증하는 경계 테스트. 임계값이 변경되면 이 테스트가 즉시 실패하여 미탐지를 방지함.
+            이 테스트는 19:00 시작 경계만을 검증함. OVERNIGHT_LATE_START_MINUTES(19:00)가
+            임계값으로 정상 동작하는지 확인하며, 임계값이 변경되면 이 테스트가 즉시 실패하여 미탐지를 방지함.
+            05:00 경계(OVERNIGHT_EARLY_END_MINUTES)는 TestIsOvernightUnit.test_is_overnight_boundary에서
+            별도로 단위 검증하므로 이 테스트에서는 다루지 않음.
             NOTE: 19:00 슬롯이 '미래'가 되도록 now를 18:00으로 고정. (22:00으로 하면 19:00이 과거 시간이 됨)
         """
         fixed_now = datetime.now().replace(hour=18, minute=0, second=0, microsecond=0)
@@ -193,6 +195,74 @@ class TestOvernightValidation:
             mock_dt.strptime = dt_original.strptime
             with pytest.raises(PastHourSlotNotAllowedError):
                 validate_hour_slots(slots, today)
+
+    def test_slot_exactly_at_late_start_boundary_is_rejected(self):
+        """now=19:00 정각일 때 slot='19:00'은 과거(<=)로 판정되어 거부되어야 함
+
+        Rationale:
+            validate_hour_slot_not_past의 조건이 slot_minutes <= now_minutes이므로
+            정각과 일치하는 슬롯도 과거로 처리됨을 명시적으로 고정함.
+            단일 슬롯이라 overnight(심야+새벽 공존) 판별 자체가 False → 과거 검증 수행됨.
+            NOTE: now를 19:00 정각으로 고정하여 테스트 시각 의존성 제거.
+        """
+        fixed_now = datetime.now().replace(hour=19, minute=0, second=0, microsecond=0)
+        today = fixed_now.strftime("%Y-%m-%d")
+        with patch("app.validate.hour_validator.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.strptime = dt_original.strptime
+            with pytest.raises(PastHourSlotNotAllowedError):
+                validate_hour_slots(["19:00"], today)
+
+    def test_slot_at_late_start_boundary_passes_when_one_minute_before(self):
+        """now=18:59일 때 slot='19:00'은 미래로 판정되어 통과해야 함
+
+        Rationale:
+            now_minutes=18*60+59=1139 < slot_minutes=1140(19:00) → 미래 슬롯 통과.
+            test_slot_exactly_at_late_start_boundary_is_rejected과 쌍으로 두어
+            정각(==과거)과 정각 1분 전(==미래)의 경계를 잠금함.
+        """
+        fixed_now = datetime.now().replace(hour=18, minute=59, second=0, microsecond=0)
+        today = fixed_now.strftime("%Y-%m-%d")
+        with patch("app.validate.hour_validator.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.strptime = dt_original.strptime
+            # 1분 이른 now → 19:00은 미래 → 예외 없이 통과
+            validate_hour_slots(["19:00"], today)
+
+    def test_05_00_slot_alone_is_rejected_as_past(self):
+        """05:00 단독 슬롯은 overnight skip 대상이 아닌 일반 과거 슬롯으로 거부되어야 함
+
+        Rationale:
+            05:00(300분)은 OVERNIGHT_EARLY_END_MINUTES(04:00=240분) 초과 → overnight skip 제외.
+            심야 슬롯(19:00 이상)도 없으므로 _is_overnight=False → 과거 검증 수행됨.
+            now=10:00 기준 05:00(300분) < 600분 → 과거 → PastHourSlotNotAllowedError 발생해야 함.
+            05:00이 overnight skip에 포함되는 회귀를 방지함.
+        """
+        fixed_now = datetime.now().replace(hour=10, minute=0, second=0, microsecond=0)
+        today = fixed_now.strftime("%Y-%m-%d")
+        with patch("app.validate.hour_validator.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.strptime = dt_original.strptime
+            with pytest.raises(PastHourSlotNotAllowedError):
+                validate_hour_slots(["05:00"], today)
+
+    def test_24_00_marker_in_non_overnight_is_treated_as_future(self):
+        """24:00(end-of-day 마커)은 overnight skip 대상 아닌 미래 슬롯으로 통과해야 함
+
+        Rationale:
+            24:00 = 1440분 > OVERNIGHT_EARLY_END_MINUTES(240분) → overnight skip 아님.
+            ['23:00','24:00']는 has_early_morning=False(최솟값 1380 > 240) → overnight 아님.
+            now=22:00(1320분): 23:00(1380)>1320, 24:00(1440)>1320 → 둘 다 미래 → 통과.
+            24:00을 과거 판정하거나 overnight 새벽으로 오분류하는 회귀를 방지함.
+            NOTE: validate_hour_continuous에서 1440-1380=60 → 연속성 통과.
+        """
+        fixed_now = datetime.now().replace(hour=22, minute=0, second=0, microsecond=0)
+        today = fixed_now.strftime("%Y-%m-%d")
+        with patch("app.validate.hour_validator.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.strptime = dt_original.strptime
+            # 24:00은 1440분으로 미래, overnight skip 대상 아님 → 예외 없이 통과
+            validate_hour_slots(["23:00", "24:00"], today)
 
 
 class TestIsOvernightUnit:

--- a/tests/exception/test_hour_validator.py
+++ b/tests/exception/test_hour_validator.py
@@ -13,7 +13,11 @@ from app.validate.hour_validator import (
     validate_hour_slot_format,
     validate_hour_slot_not_past,
     validate_hour_slots,
+    _is_overnight,
+    OVERNIGHT_LATE_START_MINUTES,
+    OVERNIGHT_EARLY_END_MINUTES,
 )
+
 
 
 def test_validate_hour_slots_invalid_format():
@@ -127,3 +131,51 @@ class TestOvernightValidation:
             mock_dt.strptime.side_effect = datetime.strptime
             with pytest.raises(PastHourSlotNotAllowedError):
                 validate_hour_slots(["12:00", "13:00"], today)  # 연속 + 14:00 기준 과거
+
+    @pytest.mark.parametrize("slots", [
+        # [19:00 경계] 정확히 19:00부터 시작하는 overnight 5시간 예약 (end-inclusive 6슬롯)
+        # NOTE: 05:00 경계 케이스는 19:00 이상→05:00 최소 10시간 거리라 5시간 제한 내 불가.
+        #       05:00 경계는 _is_overnight() 단위테스트(TestIsOvernightUnit)에서 직접 검증.
+        ["19:00", "20:00", "21:00", "22:00", "23:00", "00:00"],
+    ])
+    def test_overnight_boundary_slots_are_not_rejected(self, slots):
+        """19:00·05:00 경계값이 포함된 연속 overnight 슬롯은 과거 판정 없이 통과해야 함
+
+        Rationale:
+            OVERNIGHT_LATE_START_MINUTES(19:00)·OVERNIGHT_EARLY_END_MINUTES(05:00) 상수를
+            직접 검증하는 경계 테스트. 임계값이 변경되면 이 테스트가 즉시 실패하여 미탐지를 방지함.
+            NOTE: 19:00 슬롯이 '미래'가 되도록 now를 18:00으로 고정. (22:00으로 하면 19:00이 과거 시간이 됨)
+        """
+        fixed_now = datetime.now().replace(hour=18, minute=0, second=0, microsecond=0)
+        today = fixed_now.strftime("%Y-%m-%d")
+        with patch("app.validate.hour_validator.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.strptime.side_effect = datetime.strptime
+            # overnight으로 판별되어 새벽 슬롯이 과거 판정에서 제외 → 예외 없이 통과해야 함
+            validate_hour_slots(slots, today)
+
+
+class TestIsOvernightUnit:
+    """_is_overnight() 헬퍼 함수 단위 테스트 (경계값 중점)"""
+
+    @pytest.mark.parametrize("minutes,expected", [
+        # overnight O: 정확히 경계값 포함
+        ([OVERNIGHT_LATE_START_MINUTES, 60], True),          # 19:00 + 01:00
+        ([OVERNIGHT_EARLY_END_MINUTES, 1200], True),         # 05:00 + 20:00
+        ([OVERNIGHT_LATE_START_MINUTES, OVERNIGHT_EARLY_END_MINUTES], True),  # 양쪽 경계
+        ([1380, 60], True),                                  # 23:00 + 01:00
+        # overnight X: 경계보다 1단위 미달/초과
+        ([OVERNIGHT_LATE_START_MINUTES - 60, 60], False),    # 18:00(경계 미만) + 01:00
+        ([1200, OVERNIGHT_EARLY_END_MINUTES + 60], False),   # 20:00 + 06:00(경계 초과)
+        ([1200, 480], False),                                # 20:00만 있고 새벽 없음
+        ([60, OVERNIGHT_EARLY_END_MINUTES], False),          # 01:00만 있고 심야 없음
+    ])
+    def test_is_overnight_boundary(self, minutes, expected):
+        """_is_overnight()가 19:00/05:00 경계값을 포함(inclusive) 처리하는지 검증
+
+        Rationale:
+            OVERNIGHT_LATE_START_MINUTES·OVERNIGHT_EARLY_END_MINUTES 상수를 >= / <= 로
+            비교하므로 경계값 자체도 overnight으로 판별되어야 함.
+            이 테스트가 실패하면 상수 또는 비교 연산자가 잘못 변경된 것임.
+        """
+        assert _is_overnight(minutes) == expected

--- a/tests/exception/test_hour_validator.py
+++ b/tests/exception/test_hour_validator.py
@@ -11,6 +11,7 @@ from app.validate.hour_validator import (
     validate_hour_continuous,
     validate_hour_slot_format,
     validate_hour_slot_not_past,
+    validate_hour_slots,
 )
 
 
@@ -89,3 +90,31 @@ def test_validate_hour_slots_equal_time_should_fail():
 
     with pytest.raises(PastHourSlotNotAllowedError):
         validate_hour_slot_not_past(slot, today)
+
+
+class TestOvernightValidation:
+    """자정 교차(overnight) 예약 슬롯 과거 검증 테스트"""
+
+    def test_overnight_today_early_morning_slots_are_not_rejected(self):
+        """오늘 날짜 23:00~01:00 예약 시 자정 이후 슬롯은 과거 판정하지 않아야 함
+
+        Rationale:
+            23:00~01:00은 다음날 새벽 슬롯(00:00, 01:00)을 포함하므로
+            today 기준 과거 시간 비교에서 제외되어야 함.
+        """
+        today = datetime.now().strftime("%Y-%m-%d")
+        # 24:00 표기 또는 00:00~05:00 범위 슬롯이 포함된 overnight 슬롯 배열
+        slots = ["23:00", "00:00", "01:00"]
+        # 예외 없이 통과해야 함
+        validate_hour_slots(slots, today)
+
+    def test_non_overnight_today_past_slot_is_still_rejected(self):
+        """overnight이 아닌 일반 오늘 예약에서는 과거 슬롯이 여전히 거부되어야 함"""
+        now = datetime.now()
+        if now.hour < 1:
+            pytest.skip("새벽 00시대에는 과거 슬롯 생성이 어려워 건너뜁니다.")
+        today = now.strftime("%Y-%m-%d")
+        past_slot = f"{(now.hour - 1):02d}:00"  # 1시간 전 슬롯
+        future_slot = f"{min(now.hour + 1, 23):02d}:00"
+        with pytest.raises(PastHourSlotNotAllowedError):
+            validate_hour_slots([past_slot, future_slot], today)

--- a/tests/exception/test_hour_validator.py
+++ b/tests/exception/test_hour_validator.py
@@ -126,4 +126,4 @@ class TestOvernightValidation:
             mock_dt.now.return_value = fixed_now
             mock_dt.strptime.side_effect = datetime.strptime
             with pytest.raises(PastHourSlotNotAllowedError):
-                validate_hour_slots(["12:00", "15:00"], today)
+                validate_hour_slots(["12:00", "13:00"], today)  # 연속 + 14:00 기준 과거

--- a/tests/exception/test_hour_validator.py
+++ b/tests/exception/test_hour_validator.py
@@ -1,4 +1,5 @@
 ﻿from datetime import datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 
@@ -101,20 +102,28 @@ class TestOvernightValidation:
         Rationale:
             23:00~01:00은 다음날 새벽 슬롯(00:00, 01:00)을 포함하므로
             today 기준 과거 시간 비교에서 제외되어야 함.
+            NOTE: datetime.now()를 22:00으로 고정하여 시간 의존성을 제거함.
         """
-        today = datetime.now().strftime("%Y-%m-%d")
-        # 24:00 표기 또는 00:00~05:00 범위 슬롯이 포함된 overnight 슬롯 배열
+        fixed_now = datetime.now().replace(hour=22, minute=0, second=0, microsecond=0)
+        today = fixed_now.strftime("%Y-%m-%d")
         slots = ["23:00", "00:00", "01:00"]
-        # 예외 없이 통과해야 함
-        validate_hour_slots(slots, today)
+        with patch("app.validate.hour_validator.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.strptime.side_effect = datetime.strptime
+            # 예외 없이 통과해야 함
+            validate_hour_slots(slots, today)
 
     def test_non_overnight_today_past_slot_is_still_rejected(self):
-        """overnight이 아닌 일반 오늘 예약에서는 과거 슬롯이 여전히 거부되어야 함"""
-        now = datetime.now()
-        if now.hour < 1:
-            pytest.skip("새벽 00시대에는 과거 슬롯 생성이 어려워 건너뜁니다.")
-        today = now.strftime("%Y-%m-%d")
-        past_slot = f"{(now.hour - 1):02d}:00"  # 1시간 전 슬롯
-        future_slot = f"{min(now.hour + 1, 23):02d}:00"
-        with pytest.raises(PastHourSlotNotAllowedError):
-            validate_hour_slots([past_slot, future_slot], today)
+        """overnight이 아닌 일반 오늘 예약에서는 과거 슬롯이 여전히 거부되어야 함
+
+        Rationale:
+            overnight 스킵 로직이 일반 과거 시간 검증을 약화시키지 않는지 회귀 방지.
+            NOTE: datetime.now()를 14:00으로 고정하여 시간 의존성을 제거함.
+        """
+        fixed_now = datetime.now().replace(hour=14, minute=0, second=0, microsecond=0)
+        today = fixed_now.strftime("%Y-%m-%d")
+        with patch("app.validate.hour_validator.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.strptime.side_effect = datetime.strptime
+            with pytest.raises(PastHourSlotNotAllowedError):
+                validate_hour_slots(["12:00", "15:00"], today)

--- a/tests/exception/test_hour_validator.py
+++ b/tests/exception/test_hour_validator.py
@@ -1,4 +1,5 @@
 ﻿from datetime import datetime, timedelta
+from datetime import datetime as dt_original
 from unittest.mock import patch
 
 import pytest
@@ -113,7 +114,7 @@ class TestOvernightValidation:
         slots = ["23:00", "00:00", "01:00"]
         with patch("app.validate.hour_validator.datetime") as mock_dt:
             mock_dt.now.return_value = fixed_now
-            mock_dt.strptime.side_effect = datetime.strptime
+            mock_dt.strptime = dt_original.strptime  # side_effect 대신 직접 할당으로 호출 경로를 명확히 함
             # 예외 없이 통과해야 함
             validate_hour_slots(slots, today)
 
@@ -128,7 +129,7 @@ class TestOvernightValidation:
         today = fixed_now.strftime("%Y-%m-%d")
         with patch("app.validate.hour_validator.datetime") as mock_dt:
             mock_dt.now.return_value = fixed_now
-            mock_dt.strptime.side_effect = datetime.strptime
+            mock_dt.strptime = dt_original.strptime  # side_effect 대신 직접 할당으로 호출 경로를 명확히 함
             with pytest.raises(PastHourSlotNotAllowedError):
                 validate_hour_slots(["12:00", "13:00"], today)  # 연속 + 14:00 기준 과거
 
@@ -150,9 +151,48 @@ class TestOvernightValidation:
         today = fixed_now.strftime("%Y-%m-%d")
         with patch("app.validate.hour_validator.datetime") as mock_dt:
             mock_dt.now.return_value = fixed_now
-            mock_dt.strptime.side_effect = datetime.strptime
+            mock_dt.strptime = dt_original.strptime  # side_effect 대신 직접 할당으로 호출 경로를 명확히 함
             # overnight으로 판별되어 새벽 슬롯이 과거 판정에서 제외 → 예외 없이 통과해야 함
             validate_hour_slots(slots, today)
+
+    def test_overnight_exact_boundary_23_to_04(self):
+        """23:00~04:00 (OVERNIGHT_EARLY_END_MINUTES = 04:00 정각 경계) overnight는 예외 없이 통과해야 함
+
+        Rationale:
+            최대 5시간 overnight의 가장 늦은 조합 '23:00 ~ 04:00'을 검증.
+            OVERNIGHT_EARLY_END_MINUTES(04:00, 240분)가 <= 비교이므로
+            04:00 슬롯(240분)이 overnight 새벽으로 판별되어 과거 검증에서 제외되어야 함.
+            임계값(<=)을 < 로 잘못 변경하면 이 테스트가 즉시 실패하여 미탐지를 방지함.
+            NOTE: 05:00(300분)은 OVERNIGHT_EARLY_END_MINUTES(240분) 초과라 overnight skip 대상이 아님.
+                  19:00+05:00 조합은 10시간이므로 DTO 5시간 제한에도 위배됨. 해당 경계는
+                  TestIsOvernightUnit.test_is_overnight_boundary에서 단위 검증함.
+            NOTE: 23:00 슬롯이 미래가 되도록 now를 22:00으로 고정.
+        """
+        fixed_now = datetime.now().replace(hour=22, minute=0, second=0, microsecond=0)
+        today = fixed_now.strftime("%Y-%m-%d")
+        slots = ["23:00", "00:00", "01:00", "02:00", "03:00", "04:00"]  # 정확히 5시간
+        with patch("app.validate.hour_validator.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.strptime = dt_original.strptime
+            # 04:00이 overnight 새벽으로 판별되어 과거 검증 제외 → 예외 없이 통과
+            validate_hour_slots(slots, today)
+
+    def test_non_overnight_early_morning_past_rejected(self):
+        """overnight이 아닌데 새벽 슬롯만 있는 경우 과거 시간으로 거부되어야 함
+
+        Rationale:
+            02:00, 03:00은 19:00 이상 슬롯이 없으므로 overnight 미해당.
+            14:00 기준으로 02:00~03:00은 이미 과거이므로 PastHourSlotNotAllowedError 발생해야 함.
+            overnight 스킵 로직이 일반 새벽 과거 슬롯을 잘못 통과시키지 않는지 회귀 방지.
+        """
+        fixed_now = datetime.now().replace(hour=14, minute=0, second=0, microsecond=0)
+        today = fixed_now.strftime("%Y-%m-%d")
+        slots = ["02:00", "03:00"]  # 심야 슬롯 없음 → overnight 아님, 모두 과거
+        with patch("app.validate.hour_validator.datetime") as mock_dt:
+            mock_dt.now.return_value = fixed_now
+            mock_dt.strptime = dt_original.strptime
+            with pytest.raises(PastHourSlotNotAllowedError):
+                validate_hour_slots(slots, today)
 
 
 class TestIsOvernightUnit:


### PR DESCRIPTION
## 0. 도입 배경 (Background)
- 당일 밤 예약(예: 23:00~01:00)을 진행할 때, 자정을 넘긴 새벽 시간대(00:00, 01:00)가 오늘을 기준으로 과거 시간으로 잘못 판정되어 Hour-002(과거 시간 허용 안 됨) 400 에러를 반환하는 문제가 발생했습니다.
- 이를 해결하여 당일에 정상적인 자정 교차(Overnight) 예약이 가능하도록 검증 로직을 수정하고자 합니다.

## 1. 주요 변경 사항 (Proposed Changes)
- 자정 교차(Overnight) 예약 판별 로직 추가
  - 당일(input_date == today) 예약이더라도, 19:00 이후 슬롯과 05:00 이전 슬롯이 공존하면 자정을 넘기는 'overnight' 예약으로 간주하도록 수정했습니다.
  - 이 기준은 기존 validate_hour_continuous 함수에서 연속성 검증에 사용하던 기준(19:00/05:00)과 동일하게 맞추어 코드의 일관성을 유지했습니다.
- 새벽 슬롯에 대한 예외 처리
  - overnight 예약으로 판정되면, 자정 이후의 새벽 슬롯(00:00 ~ 05:00)은 실제로는 '다음날'이므로, 오늘 기준(now.time())의 과거 검증에서 제외(continue)하도록 수정했습니다.
- 시간 의존성 없는 테스트 코드 추가
  - 버그 재현 및 회귀 방지를 위해 tests/exception/test_hour_validator.py에 TestOvernightValidation을 추가했습니다. 
  - 테스트 환경(실행 시간)에 따라 성공/실패가 달라지지 않도록 unittest.mock.patch를 이용해 datetime.now()를 특정 시간(18:00, 14:00)으로 고정하여 테스트 안정성을 확보했습니다.

## 2. 체크리스트 (Checklist)
<!-- 작업하신 내용이 완료되었는지 체크해 주세요. -->
- [ ] 관련된 이슈를 PR 커밋 메시지 또는 본문에 링크했습니다. (`#이슈번호`)
- [ ] PR 제목은 `[#이슈번호]; <태그>: <설명>` 컨벤션을 준수했습니다.
- [ ] 새로 작성된 함수와 클래스에는 `Google Style Docstring`(의도, 파라미터 등)이 포함되어 있습니다.
- [ ] 테스트 코드가 작성되었거나 기능 테스트가 완료되었습니다.

## 3. 참고 자료 (Optional)
<!-- 스크린샷, 관련 문서 링크 등 리뷰어가 참고할 만한 자료를 첨부해 주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Hour-slot validation now correctly handles overnight/cross-midnight schedules (19:00–04:00), uses Korea Standard Time when evaluating "now", and preserves chronological order so early-morning slots after late-night slots are validated appropriately while still rejecting past non-overnight slots.
* **Tests**
  * Added deterministic tests covering overnight acceptance, boundary cases, and non-overnight past-slot rejection (with mocked current time).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->