### PR TITLE
[#205]; refactor: 부분 가능한 합주실 unknown으로 잘못 표현한 것 수정

### DIFF
--- a/app/crawler/base.py
+++ b/app/crawler/base.py
@@ -39,23 +39,20 @@ class BaseCrawler(ABC):
         pass
 
     @staticmethod
-    def resolve_tri_state(available_slots: dict[str, bool], hour_slots: List[str] = None) -> Union[bool, str]:
+    def resolve_tri_state(available_slots: dict[str, bool], hour_slots: List[str] = None) -> bool:
         """
-        주어진 슬롯 중 예약 가능한 시간(True)이 전부인지, 일부인지, 아예 없는지에 따라
-        True, "unknown", False를 반환합니다.
+        주어진 슬롯 중 예약 가능한 시간(True)이 전부인지 확인합니다.
+        하나라도 예약 불가(False)가 있다면 False를 반환합니다.
         
         Args:
             available_slots: 시간대별 예약 가능 여부 (예: {"18:00": True, "19:00": False})
             hour_slots: 검사할 시간대 리스트. None이면 available_slots 전체를 검사합니다.
+            
+        Returns:
+            요청된 모든 슬롯이 가능하면 True, 하나라도 불가능하면 False.
         """
         values = [val for hour, val in available_slots.items() if (hour_slots is None or hour in hour_slots)]
         if not values:
             return False
             
-        all_true = all(values)
-        any_true = any(values)
-        
-        if all_true:
-            return True
-        else:
-            return False
+        return all(values)

--- a/app/crawler/base.py
+++ b/app/crawler/base.py
@@ -57,7 +57,5 @@ class BaseCrawler(ABC):
         
         if all_true:
             return True
-        elif any_true:
-            return "unknown"
         else:
             return False

--- a/app/crawler/dream_checker.py
+++ b/app/crawler/dream_checker.py
@@ -56,7 +56,7 @@ class DreamCrawler(BaseCrawler):
                 RoomAvailability(
                     room_detail=room,
                     available="unknown",
-                    available_slots={hour_str: False for hour_str in hour_slots[:-1]},
+                    available_slots={hour_str: False for hour_str in hour_slots},
                 )
                 for room in target_rooms
             ]

--- a/app/crawler/dream_checker.py
+++ b/app/crawler/dream_checker.py
@@ -56,7 +56,7 @@ class DreamCrawler(BaseCrawler):
                 RoomAvailability(
                     room_detail=room,
                     available="unknown",
-                    available_slots={hour_str: "unknown" for hour_str in hour_slots},
+                    available_slots={hour_str: False for hour_str in hour_slots[:-1]},
                 )
                 for room in target_rooms
             ]

--- a/app/crawler/groove_checker.py
+++ b/app/crawler/groove_checker.py
@@ -25,7 +25,7 @@ class GrooveCrawler(BaseCrawler):
             # 즉시 'unknown' 결과를 반환
             unknown_results = []
             for room in target_rooms:
-                slots = {hour_str: False for hour_str in hour_slots[:-1]}
+                slots = {hour_str: False for hour_str in hour_slots}
                 result = RoomAvailability(
                     room_detail=room,
                     available="unknown",

--- a/app/crawler/groove_checker.py
+++ b/app/crawler/groove_checker.py
@@ -25,7 +25,7 @@ class GrooveCrawler(BaseCrawler):
             # 즉시 'unknown' 결과를 반환
             unknown_results = []
             for room in target_rooms:
-                slots = {hour_str: "unknown" for hour_str in hour_slots}
+                slots = {hour_str: False for hour_str in hour_slots[:-1]}
                 result = RoomAvailability(
                     room_detail=room,
                     available="unknown",

--- a/app/models/dto.py
+++ b/app/models/dto.py
@@ -286,8 +286,8 @@ class RoomInfo(BaseModel):
 class RoomAvailability(BaseModel):
     """Availability information for a single room (Internal Use)"""
     room_detail: RoomDetail = Field(..., description="Room detail information")
-    available: Union[bool, str] = Field(..., description="Availability status (true/false/unknown)")
-    available_slots: Dict[str, Union[bool, str]] = Field(..., description="Availability by time slot")
+    available: Union[bool, str] = Field(..., description="Availability status (true: Available, false: Unavailable or Partial, 'unknown': Standby/Not Opened)")
+    available_slots: Dict[str, Union[bool, str]] = Field(..., description="Availability by time slot (false for standby)")
     
     # [v2.0.0] 추가 정보
     estimated_price: Optional[int] = Field(None, description="Calculated total price")
@@ -299,8 +299,8 @@ class RoomResponse(BaseModel):
     biz_item_id: str
     name: str
     price_per_hour: int
-    available: Union[bool, str]
-    available_slots: Dict[str, Union[bool, str]]
+    available: Union[bool, str] = Field(..., description="Availability status (true: Available, false: Unavailable or Partial, 'unknown': Standby/Not Opened)")
+    available_slots: Dict[str, Union[bool, str]] = Field(..., description="Availability by time slot")
     estimated_price: Optional[int] = None
     image_urls: List[str]
     max_capacity: int

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -477,7 +477,7 @@ class AvailabilityService:
                 else:
                     branch_obj = branch_dict[bid]
                     branch_obj.rooms.append(room_resp)
-                    if res.available is not "unknown":
+                    if res.available != "unknown":
                         branch_obj.available_count += 1
                     
                     AvailabilityService._update_min_prices(branch_obj, res.available, total_price, is_partial)

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -312,6 +312,7 @@ class AvailabilityService:
         
         for room in target_rooms:
             if room.standbyDays is not None and days_diff < room.standbyDays:
+                logger.info(f"[standby_filter] biz_item_id={room.biz_item_id} excluded: standby_days={room.standbyDays} > days_diff={days_diff}")
                 standby_results.append(RoomAvailability(
                     room_detail=room,
                     available="unknown",
@@ -419,6 +420,8 @@ class AvailabilityService:
                 logger.warning(f"Unexpected available value: {res.available!r} for biz_item_id={room_detail.biz_item_id}")
 
             is_partial = is_partial_available(res)
+            if is_partial:
+                logger.info(f"[partial_availability] biz_item_id={room_detail.biz_item_id} marked as partial (available=False but has true slots)")
 
             # 예약 가능한 룸, 부분 예약 룸, 결제 불가능한 오픈대기 룸만 포함
             if res.available is True or res.available == "unknown" or is_partial:

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -294,6 +294,24 @@ class AvailabilityService:
         
         validate_availability_request(request.date, hour_slots, target_rooms)
 
+        # 2.5. 오픈 대기 상태 검증 (standby_days 기준 예약 불가능한 방 미리 걸러내기)
+        today = datetime.now().date()
+        target_date_obj = datetime.strptime(request.date, "%Y-%m-%d").date()
+        days_diff = (target_date_obj - today).days
+
+        standby_results = []
+        crawling_rooms = []
+        
+        for room in target_rooms:
+            if room.standbyDays is not None and days_diff < room.standbyDays:
+                standby_results.append(RoomAvailability(
+                    room_detail=room,
+                    available="unknown",
+                    available_slots={hour_str: "unknown" for hour_str in hour_slots}
+                ))
+            else:
+                crawling_rooms.append(room)
+
         # 3. 크롤러 비동기 작업 준비 및 실행
         tasks = []
         task_dates = []
@@ -302,12 +320,8 @@ class AvailabilityService:
         end_min = self._slot_to_minutes(request.end_hour)
         is_overnight = (start_mins > end_min)
         
-        # [중요] 사용자가 요청한 시간 범위를 조회하기 위한 시작 슬롯들만 추출 (마지막 경계 슬롯 제외)
-        # 예: 23:00 ~ 01:00 요청 시 hour_slots는 ["23:00", "00:00", "01:00"] 이며,
-        # 체크해야 할 시작 타임은 ["23:00", "00:00"] 입니다.
         slots_to_check = hour_slots[:-1]
 
-        # [최적화] 루프 내부 반복 연산을 줄이기 위해 크롤러 루프 외부에서 1회만 계산
         if is_overnight:
             day1_slots = [slot for slot in slots_to_check if self._slot_to_minutes(slot) >= start_mins]
             day2_slots = [slot for slot in slots_to_check if slot not in day1_slots]
@@ -317,7 +331,7 @@ class AvailabilityService:
             day2_slots = []
 
         for crawler_type, crawler in self.crawlers_map.items():
-            filtered_rooms = filter_rooms_by_type(target_rooms, crawler_type)
+            filtered_rooms = filter_rooms_by_type(crawling_rooms, crawler_type)
             if filtered_rooms:
                 if is_overnight:
                     if day1_slots:
@@ -330,7 +344,7 @@ class AvailabilityService:
                     tasks.append(crawler.check_availability(request.date, day1_slots, filtered_rooms))
                     task_dates.append(request.date)
 
-        if not tasks:
+        if not tasks and not standby_results:
             return AvailabilityResponse(
                 date=request.date,
                 start_hour=request.start_hour,
@@ -340,9 +354,9 @@ class AvailabilityService:
                 branches=[]
             )
 
-        results_of_lists = await asyncio.gather(*tasks)
+        results_of_lists = await asyncio.gather(*tasks) if tasks else []
         
-        all_results = []
+        all_results = list(standby_results)
         for res_list, t_date in zip(results_of_lists, task_dates, strict=True):
             for item in res_list:
                 if isinstance(item, Exception):
@@ -364,7 +378,10 @@ class AvailabilityService:
                 if existing.available == r.available:
                     pass # 동일 상태면 유지
                 else:
-                    existing.available = "unknown" # 상태가 엇갈리거나 이미 unknown이면 그대로 unknown
+                    if existing.available == "unknown" or r.available == "unknown":
+                        existing.available = "unknown" # 상태가 엇갈리거나 이미 unknown이면 그대로 unknown
+                    else:
+                        existing.available = False # True 와 False 엇갈림 -> False
                     
                 # 2. 각 시간대별 슬롯 가능 여부 딕셔너리 병합
                 existing.available_slots.update(r.available_slots)
@@ -393,8 +410,10 @@ class AvailabilityService:
             if res.available not in (True, False, "unknown"):
                 logger.warning(f"Unexpected available value: {res.available!r} for biz_item_id={room_detail.biz_item_id}")
 
-            # 예약 가능한 룸만 결과에 포함
-            if res.available is True or res.available == "unknown":
+            is_partial = (res.available is False and isinstance(res.available_slots, dict) and any(v is True for v in res.available_slots.values()))
+
+            # 예약 가능한 룸, 부분 예약 룸, 결제 불가능한 오픈대기 룸만 포함
+            if res.available is True or res.available == "unknown" or is_partial:
                 if isinstance(res.estimated_price, int) and res.estimated_price > 0:
                     total_price = res.estimated_price
                 else:
@@ -402,7 +421,7 @@ class AvailabilityService:
                         room_detail=room_detail,
                         date_str=request.date,
                         hour_slots=hour_slots,
-                        available_slots=res.available_slots if res.available == "unknown" else None,
+                        available_slots=res.available_slots if is_partial else None,
                     )
 
                 room_resp = RoomResponse(
@@ -411,7 +430,7 @@ class AvailabilityService:
                     price_per_hour=room_detail.pricePerHour,
                     available=res.available,
                     available_slots=res.available_slots,
-                    estimated_price=total_price,
+                    estimated_price=total_price if res.available is not False else None,
                     image_urls=room_detail.imageUrls,
                     max_capacity=room_detail.maxCapacity,
                     # [이슈 6] fallback 계산 제거됨 (recommendCapacity가 None이면 0이 될 수 있음, 클라이언트에서 처리 필요)
@@ -422,7 +441,7 @@ class AvailabilityService:
                     min_capacity=room_detail.minCapacity,
                     min_hours=room_detail.minHours,
                     max_hours=room_detail.maxHours,
-                    standby_days=room_detail.standbyDays,
+                    standby_days=room_detail.standbyDays if res.available == "unknown" else None,
                     policy_warnings=res.policy_warnings
                 )
 
@@ -442,13 +461,13 @@ class AvailabilityService:
                         display_name=room_detail.displayName,
                         rooms=[room_resp]
                     )
-                    AvailabilityService._update_min_prices(branch_dict[bid], res.available, total_price)
+                    AvailabilityService._update_min_prices(branch_dict[bid], res.available, total_price, is_partial)
                 else:
                     branch_obj = branch_dict[bid]
                     branch_obj.rooms.append(room_resp)
                     branch_obj.available_count += 1
                     
-                    AvailabilityService._update_min_prices(branch_obj, res.available, total_price)
+                    AvailabilityService._update_min_prices(branch_obj, res.available, total_price, is_partial)
                     
                     if not branch_obj.phone_number and room_detail.phoneNumber:
                         branch_obj.phone_number = room_detail.phoneNumber
@@ -465,11 +484,11 @@ class AvailabilityService:
         )
 
     @staticmethod
-    def _update_min_prices(branch_obj: BranchResponse, available: bool | str, total_price: int) -> None:
+    def _update_min_prices(branch_obj: BranchResponse, available: bool | str, total_price: int, is_partial: bool = False) -> None:
         if available is True:
             if branch_obj.min_price_available is None or total_price < branch_obj.min_price_available:
                 branch_obj.min_price_available = total_price
-        elif available == "unknown":
+        elif is_partial:
             if branch_obj.min_price_partial is None or total_price < branch_obj.min_price_partial:
                 branch_obj.min_price_partial = total_price
 
@@ -594,12 +613,14 @@ class AvailabilityService:
                     message=f"최대 {room.maxHours}시간까지만 예약할 수 있습니다.",
                 ))
 
-            if res.available is True or res.available == "unknown":
+            is_partial = (res.available is False and isinstance(res.available_slots, dict) and any(v is True for v in res.available_slots.values()))
+            
+            if res.available is True or is_partial:
                 try:
                     if isinstance(room.priceConfig, dict):
                         price = self.calculate_total_price(
                             room, request.date, hour_slots,
-                            available_slots=res.available_slots if res.available == "unknown" else None,
+                            available_slots=res.available_slots if is_partial else None,
                         )
                     else:
                         normalized_rules = (
@@ -616,12 +637,12 @@ class AvailabilityService:
                             f"{request.date} {end_slot}", "%Y-%m-%d %H:%M"
                         )
                         
-                        # [심야 예약 대응] 종료 시간이 시작 시간보다 같거나 빠르면 익일로 간주
+                        # 심야 예약 대응] 종료 시간이 시작 시간보다 같거나 빠르면 익일로 간주
                         if end_dt <= start_dt:
                             end_dt += timedelta(days=1)
 
-                        # 부분 예약 가능(unknown)인 경우, 가장 길게 연속으로 예약 가능한 덩어리(블록) 하나만 합산
-                        if res.available == "unknown":
+                        # 부분 예약 가능(partial)인 경우, 가장 길게 연속으로 예약 가능한 덩어리(블록) 하나만 합산
+                        if is_partial:
                             longest_block = []
                             current_block = []
                             

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -41,6 +41,14 @@ from app.validate.room_detail_validator import validate_room_detail_list
 
 logger = logging.getLogger("app")
 
+def is_partial_available(res: RoomAvailability) -> bool:
+    """방이 부분적으로 예약 가능한지 (available은 False이지만 내부에 빈 슬롯이 있는지) 확인합니다."""
+    return (
+        res.available is False 
+        and isinstance(res.available_slots, dict) 
+        and any(v is True for v in res.available_slots.values())
+    )
+
 class AvailabilityService:
     """합주실 예약 가능 여부 조회 서비스
     
@@ -410,7 +418,7 @@ class AvailabilityService:
             if res.available not in (True, False, "unknown"):
                 logger.warning(f"Unexpected available value: {res.available!r} for biz_item_id={room_detail.biz_item_id}")
 
-            is_partial = (res.available is False and isinstance(res.available_slots, dict) and any(v is True for v in res.available_slots.values()))
+            is_partial = is_partial_available(res)
 
             # 예약 가능한 룸, 부분 예약 룸, 결제 불가능한 오픈대기 룸만 포함
             if res.available is True or res.available == "unknown" or is_partial:
@@ -624,7 +632,7 @@ class AvailabilityService:
                     message=f"최대 {room.maxHours}시간까지만 예약할 수 있습니다.",
                 ))
 
-            is_partial = (res.available is False and isinstance(res.available_slots, dict) and any(v is True for v in res.available_slots.values()))
+            is_partial = is_partial_available(res)
             
             if res.available is True or is_partial:
                 try:

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -307,7 +307,7 @@ class AvailabilityService:
                 standby_results.append(RoomAvailability(
                     room_detail=room,
                     available="unknown",
-                    available_slots={hour_str: "unknown" for hour_str in hour_slots}
+                    available_slots={hour_str: False for hour_str in hour_slots[:-1]}
                 ))
             else:
                 crawling_rooms.append(room)
@@ -445,7 +445,8 @@ class AvailabilityService:
                     policy_warnings=res.policy_warnings
                 )
 
-                available_ids.append(room_detail.biz_item_id)
+                if res.available != "unknown":
+                    available_ids.append(room_detail.biz_item_id)
                 bid = room_detail.business_id
                 
                 if bid not in branch_dict:
@@ -456,7 +457,7 @@ class AvailabilityService:
                         lng=room_detail.lng,
                         min_price_available=None,
                         min_price_partial=None,
-                        available_count=1,
+                        available_count=1 if res.available != "unknown" else 0,
                         phone_number=room_detail.phoneNumber,
                         display_name=room_detail.displayName,
                         rooms=[room_resp]
@@ -465,7 +466,8 @@ class AvailabilityService:
                 else:
                     branch_obj = branch_dict[bid]
                     branch_obj.rooms.append(room_resp)
-                    branch_obj.available_count += 1
+                    if res.available is not "unknown":
+                        branch_obj.available_count += 1
                     
                     AvailabilityService._update_min_prices(branch_obj, res.available, total_price, is_partial)
                     
@@ -485,6 +487,15 @@ class AvailabilityService:
 
     @staticmethod
     def _update_min_prices(branch_obj: BranchResponse, available: bool | str, total_price: int, is_partial: bool = False) -> None:
+        """
+        지점(Branch) 단위의 최소 예약 가능 가격을 갱신합니다.
+        
+        Args:
+            branch_obj: 대상 지점 응답 모델
+            available: 방의 현재 예약 상태 (True, False, "unknown")
+            total_price: 계산된 총 가격
+            is_partial: 해당 방이 예약 상태는 False지만 부분적으로 이용 가능한 슬롯이 있는지 여부
+        """
         if available is True:
             if branch_obj.min_price_available is None or total_price < branch_obj.min_price_available:
                 branch_obj.min_price_available = total_price
@@ -637,7 +648,7 @@ class AvailabilityService:
                             f"{request.date} {end_slot}", "%Y-%m-%d %H:%M"
                         )
                         
-                        # 심야 예약 대응] 종료 시간이 시작 시간보다 같거나 빠르면 익일로 간주
+                        # [심야 예약 대응] 종료 시간이 시작 시간보다 같거나 빠르면 익일로 간주
                         if end_dt <= start_dt:
                             end_dt += timedelta(days=1)
 

--- a/docs/frontend_guide.md
+++ b/docs/frontend_guide.md
@@ -138,14 +138,14 @@ API 응답(`AvailabilityResponse`)의 전체 구조는 다음과 같습니다. �
 ### 4-1. `available` 필드 상태값 (Enum)
 *   `true` (Boolean): 예약 가능 (요청한 전체 시간에 대해 빈 방)
 *   `false` (Boolean): 예약 불가 (이미 예약됨)
-*   `"unknown"` (String): **부분 예약 가능** (요청한 시간 중 일부 시간만 비어있음)
+*   `"unknown"` (String): **오픈 대기** (요청한 날짜가 아직 예약 오픈 기간이 아니거나 대기 중임. 예약 불가)
 
 ### 4-2. `min_price_available` 및 `min_price_partial` 필드 정책
 두 필드의 키(key)는 결괏값에 **항상 포함**되며 조건부로 생략되지 않습니다.
 값이 `null`이 되는 경우는 다음과 같습니다.
 
 *   `min_price_available`: 결과 룸들 중 `available: true`인 방이 **하나도 없을 때** `null`이 됩니다. 예약 가능한 방이 하나라도 있으면 최소 가격(숫자)이 들어갑니다.
-*   `min_price_partial`: 결과 룸들 중 `available: "unknown"`인 방이 **하나도 없을 때** `null`이 됩니다. 부분 예약 가능한 방이 하나라도 있으면 가장 길게 연속된 예약가능 시간 기준의 최소 가격(숫자)이 들어갑니다.
+*   `min_price_partial`: 결과 룸들 중 `available: false` 이면서 슬롯 일부가 비어있는 방이 **하나도 없을 때** `null`이 됩니다. 부분 예약 가능한 방이 하나라도 있으면 가장 길게 연속된 예약가능 시간 기준의 최소 가격(숫자)이 들어갑니다. (오픈 대기인 `"unknown"` 방은 이 계산에서 제외됩니다.)
 
 **예시 JSON:**
 1) 부분 예약만 가능한 방만 있는 경우

--- a/docs/frontend_guide.md
+++ b/docs/frontend_guide.md
@@ -106,11 +106,11 @@ API 응답(`AvailabilityResponse`)의 전체 구조는 다음과 같습니다. �
           "name": "A룸",
           "available": "unknown",         // true / false / "unknown"
           "available_slots": {
-            "17:00": true,
+            "17:00": false,
             "18:00": false
           },
           "price_per_hour": 15000,
-          "estimated_price": 45000,       // [NEW] 계산된 최종 예상 금액 (시간/인동 동적 계산)
+          "estimated_price": null,        // [NEW] 계산된 최종 예상 금액 (unknown일 경우 null)
           "image_urls": [
             "https://example.com/image1.jpg"
           ],

--- a/tests/api/test_available_room_map.py
+++ b/tests/api/test_available_room_map.py
@@ -149,7 +149,7 @@ async def test_map_search_success_partial(
 ):
     """
     [통합 시나리오 테스트]
-    방이 'unknown' (예약 일부 가능) 상태일 때 min_price_partial 에 가격이 들어가고,
+    방이 False (예약 일부 가능 - is_partial) 상태일 때 min_price_partial 에 가격이 들어가고,
     min_price_available 은 None 이어야 한다.
     """
     room_resp = mock_room_response_factory(name="Partial Room", price=30000, available=False)

--- a/tests/api/test_available_room_map.py
+++ b/tests/api/test_available_room_map.py
@@ -152,7 +152,7 @@ async def test_map_search_success_partial(
     방이 'unknown' (예약 일부 가능) 상태일 때 min_price_partial 에 가격이 들어가고,
     min_price_available 은 None 이어야 한다.
     """
-    room_resp = mock_room_response_factory(name="Partial Room", price=30000, available="unknown")
+    room_resp = mock_room_response_factory(name="Partial Room", price=30000, available=False)
     branch_resp = mock_branch_response_factory(min_price_available=None, min_price_partial=30000, rooms=[room_resp])
     
     mock_response = mock_availability_response_factory(branches=[branch_resp])
@@ -185,7 +185,7 @@ async def test_map_search_success_mixed(
     하나의 지점에 예약 가능 방과 일부 가능 방이 혼재해 있을 때, 두 가지 최저가 모두 올바르게 계산되어야 한다.
     """
     room_resp1 = mock_room_response_factory(name="Available Room", price=25000, available=True)
-    room_resp2 = mock_room_response_factory(name="Partial Room", price=15000, available="unknown")
+    room_resp2 = mock_room_response_factory(name="Partial Room", price=15000, available=False)
     branch_resp = mock_branch_response_factory(min_price_available=25000, min_price_partial=15000, rooms=[room_resp1, room_resp2])
     
     mock_response = mock_availability_response_factory(branches=[branch_resp])

--- a/tests/services/test_availability_service.py
+++ b/tests/services/test_availability_service.py
@@ -278,7 +278,7 @@ class TestAvailabilityServiceFlow:
             room_detail=room1, available=True, available_slots={"14:00": True, "15:00": True}
         )
 
-        # 방 2: 부분 예약 가능 (available="unknown"), 예약가능한 1시간 기준 7500원 -> min_price_partial 후보
+        # 방 2: 부분 예약 가능 (available=False), 예약가능한 1시간 기준 7500원 -> min_price_partial 후보
         room2 = RoomDetail(
             name="Room2", branch="Branch", business_id=branch_id, biz_item_id="r2",
             pricePerHour=7500, max_capacity=10,
@@ -286,7 +286,7 @@ class TestAvailabilityServiceFlow:
             recommend_capacity_range=[4, 8], priceConfig={}
         )
         avail_2 = RoomAvailability(
-            room_detail=room2, available="unknown", available_slots={"14:00": True, "15:00": False},
+            room_detail=room2, available=False, available_slots={"14:00": True, "15:00": False},
             estimated_price=7500
         )
 
@@ -371,7 +371,7 @@ class TestAvailabilityServiceFlow:
             recommend_capacity_range=[4, 8], priceConfig={}
         )
         avail_1 = RoomAvailability(
-            room_detail=room1, available="unknown", available_slots={"14:00": True, "15:00": False}, estimated_price=10000
+            room_detail=room1, available=False, available_slots={"14:00": True, "15:00": False}, estimated_price=10000
         )
         
         mock_crawler.check_availability.return_value = [avail_1]

--- a/tests/services/test_availability_service.py
+++ b/tests/services/test_availability_service.py
@@ -184,6 +184,43 @@ class TestApplyPolicies:
         assert kwargs["end_dt"] == datetime(2099, 1, 2, 0, 0)
         assert results[0].estimated_price == 20000
 
+    def test_calculate_total_price_partial_longest_block(self, service):
+        """가장 긴 연속된 빈 슬롯 블록을 찾아 요금을 계산하는 로직 검증 (min_price_partial)"""
+        room = RoomDetail(
+            name="TestRoom", branch="Branch", business_id="b1", biz_item_id="r1",
+            pricePerHour=10000, max_capacity=10, 
+            priceConfig={"default": 10000},
+            can_reserve_one_hour=True, requiresContactOnSameDay=False
+        )
+        
+        # hour_slots: 14:00 ~ 18:00 (총 4슬롯 크기, billable_slots = ["14:00", "15:00", "16:00", "17:00"])
+        hour_slots = ["14:00", "15:00", "16:00", "17:00", "18:00"]
+        
+        # available 상태: 14, 15 가능 / 16 불가 / 17 가능
+        # 따라서 가장 긴 블록은 ["14:00", "15:00"] (2시간)
+        available_slots = {"14:00": True, "15:00": True, "16:00": False, "17:00": True}
+        
+        # 10000 * 2시간 = 20000원이 연산되어야 함
+        total_price = service.calculate_total_price(room, "2026-03-10", hour_slots, available_slots)
+        assert total_price == 20000
+
+    def test_calculate_total_price_overnight(self, service):
+        """심야 예약 시 자정을 넘기는 슬롯의 익일 날짜 반영 로직 검증"""
+        room = RoomDetail(
+            name="TestRoom", branch="Branch", business_id="b1", biz_item_id="r1",
+            pricePerHour=10000, max_capacity=10, 
+            priceConfig={"default": 10000, "overrides": [{"day_type": "weekday", "start_hour": "00:00", "end_hour": "06:00", "price": 15000}]},
+            can_reserve_one_hour=True, requiresContactOnSameDay=False
+        )
+        # 평일 목요일 시나리오 ("2026-03-05" is Thursday)
+        # hour_slots: 23:00 ~ 02:00 (총 3슬롯)
+        hour_slots = ["23:00", "00:00", "01:00", "02:00"]
+        
+        # 23:00 슬롯은 10000, 00:00과 01:00 슬롯은 overrides에 의해 15000이 적용되어야 함. 익일이지만 평일이라 똑같이 weekday 규칙 탑승
+        # 10000 + 15000 + 15000 = 40000원
+        total_price = service.calculate_total_price(room, "2026-03-05", hour_slots, available_slots=None)
+        assert total_price == 40000
+
 
 class TestAvailabilityServiceFlow:
     """check_availability 전체 흐름 테스트 (DB/Crawler Mocking)

--- a/tests/services/test_availability_service.py
+++ b/tests/services/test_availability_service.py
@@ -408,5 +408,73 @@ class TestAvailabilityServiceFlow:
              patch("app.services.availability_service.validate_availability_request"):
             mock_db.return_value = [room1]
             response = await service.check_availability(req)
-
         assert len(response.branches) == 0
+
+    @pytest.mark.asyncio
+    @patch("app.services.availability_service.datetime")
+    async def test_standby_days_filter(self, mock_datetime, service, mock_crawler):
+        """standby_days 기준 예약 불가능한 방 사전 필터링 검증"""
+        from datetime import datetime, date, timedelta
+        
+        # mock datetime to today
+        today_date = date.today()
+        class MockDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return datetime.combine(today_date, datetime.min.time())
+
+        mock_datetime.now = MockDatetime.now
+        mock_datetime.strptime.side_effect = datetime.strptime
+
+        # target_date is today + 7 days
+        target_date_str = (today_date + timedelta(days=7)).strftime("%Y-%m-%d")
+
+        req = AvailabilityRequest(
+            date=target_date_str, capacity=3, start_hour="14:00", end_hour="16:00",
+            swLat=37.0, swLng=126.0, neLat=38.0, neLng=127.0
+        )
+        
+        # 1. standbyDays = None 인 방 -> 크롤링 대상 포함
+        room1 = RoomDetail(
+            name="Room1", branch="Branch", business_id="b1", biz_item_id="r1",
+            pricePerHour=10000, max_capacity=10, can_reserve_one_hour=True, requiresContactOnSameDay=False,
+            recommend_capacity_range=[4, 8], priceConfig={}, standbyDays=None
+        )
+        avail_1 = RoomAvailability(room_detail=room1, available=True, available_slots={"14:00": True, "15:00": True}, estimated_price=20000)
+
+        # 2. days_diff(7) >= standbyDays(5) 인 방 -> 크롤링 대상 포함
+        room2 = RoomDetail(
+            name="Room2", branch="Branch", business_id="b1", biz_item_id="r2",
+            pricePerHour=10000, max_capacity=10, can_reserve_one_hour=True, requiresContactOnSameDay=False,
+            recommend_capacity_range=[4, 8], priceConfig={}, standbyDays=5
+        )
+        avail_2 = RoomAvailability(room_detail=room2, available=True, available_slots={"14:00": True, "15:00": True}, estimated_price=20000)
+
+        # 3. days_diff(7) < standbyDays(10) 인 방 -> 크롤링 대상 제외, available="unknown"
+        room3 = RoomDetail(
+            name="Room3", branch="Branch", business_id="b1", biz_item_id="r3",
+            pricePerHour=10000, max_capacity=10, can_reserve_one_hour=True, requiresContactOnSameDay=False,
+            recommend_capacity_range=[4, 8], priceConfig={}, standbyDays=10
+        )
+
+        mock_crawler.check_availability.return_value = [avail_1, avail_2]
+
+        with patch("app.services.availability_service.get_rooms_by_criteria") as mock_db, \
+             patch("app.services.availability_service.filter_rooms_by_type", return_value=[room1, room2]), \
+             patch("app.services.availability_service.validate_availability_request"):
+            mock_db.return_value = [room1, room2, room3]
+            response = await service.check_availability(req)
+
+        assert len(response.branches) == 1
+        branch = response.branches[0]
+        assert len(branch.rooms) == 3
+
+        r1 = next(r for r in branch.rooms if r.biz_item_id == "r1")
+        assert r1.available is True
+        
+        r2 = next(r for r in branch.rooms if r.biz_item_id == "r2")
+        assert r2.available is True
+
+        r3 = next(r for r in branch.rooms if r.biz_item_id == "r3")
+        assert r3.available == "unknown"
+        assert r3.standby_days == 10

--- a/tests/test_dream_checker.py
+++ b/tests/test_dream_checker.py
@@ -101,7 +101,7 @@ async def test_dream_partial_availability(sample_dream_rooms):
 
     room_result = result[0]
     assert isinstance(room_result, RoomAvailability)
-    assert room_result.available == "unknown"  # 일부만 가능하면 "unknown" (mixed availability)
+    assert room_result.available is False  # 일부만 가능하면 False
     assert room_result.available_slots["13:00"] is True
     assert room_result.available_slots["14:00"] is False
 

--- a/tests/test_dream_checker.py
+++ b/tests/test_dream_checker.py
@@ -118,5 +118,5 @@ async def test_dream_beyond_date_limit(sample_dream_rooms):
 
     room_result = result[0]
     assert room_result.available == "unknown"
-    assert room_result.available_slots["13:00"] == "unknown"
-    assert room_result.available_slots["14:00"] == "unknown"
+    assert room_result.available_slots["13:00"] is False
+    assert "14:00" not in room_result.available_slots

--- a/tests/test_dream_checker.py
+++ b/tests/test_dream_checker.py
@@ -119,4 +119,4 @@ async def test_dream_beyond_date_limit(sample_dream_rooms):
     room_result = result[0]
     assert room_result.available == "unknown"
     assert room_result.available_slots["13:00"] is False
-    assert "14:00" not in room_result.available_slots
+    assert room_result.available_slots["14:00"] is False

--- a/tests/test_groove_checker.py
+++ b/tests/test_groove_checker.py
@@ -93,7 +93,7 @@ async def test_availability_within_84_days_boundary(sample_groove_rooms):
     # 검증
     # check_hour_slot은 '#reserve_time_..._21.reserve_time_off'를 찾지 못하므로 False를 반환함
     result = results[0]
-    assert result.available == "unknown"  # 한 슬롯이라도 불가능하면 전체는 "unknown"
+    assert result.available is False  # 한 슬롯이라도 불가하면 전체는 False
     assert result.available_slots["20:00"] is True
     assert result.available_slots["21:00"] is False
 

--- a/tests/test_groove_checker.py
+++ b/tests/test_groove_checker.py
@@ -112,5 +112,5 @@ async def test_availability_at_and_after_84_days_boundary(sample_groove_rooms):
     # 검증
     result = results[0]
     assert result.available == "unknown"
-    assert result.available_slots["20:00"] == "unknown"
-    assert result.available_slots["21:00"] == "unknown"
+    assert result.available_slots["20:00"] is False
+    assert "21:00" not in result.available_slots

--- a/tests/test_groove_checker.py
+++ b/tests/test_groove_checker.py
@@ -113,4 +113,4 @@ async def test_availability_at_and_after_84_days_boundary(sample_groove_rooms):
     result = results[0]
     assert result.available == "unknown"
     assert result.available_slots["20:00"] is False
-    assert "21:00" not in result.available_slots
+    assert result.available_slots["21:00"] is False


### PR DESCRIPTION
## 0. 도입 배경 (Background)
기존 예약 조회 로직에서 `unknown` 상태가 "부분 예약 가능"과 "오픈 대기/예약 기간 아님" 두 가지 의미로 혼용되어 나타나고 있었습니다. 이로 인해 코드의 복잡도가 높아지고, 프론트엔드에서 상태를 직관적으로 구분하여 렌더링하기 어려웠습니다. 본 PR은 부분 예약 가능 상태를 '예약 불가'로 확실하게 분리하고, `unknown`을 오직 '오픈 대기' 전용 상태로 재정의하여 비즈니스 로직을 명확히 하기 위해 작성되었습니다.

## 1. 주요 변경 사항 (Proposed Changes)
- **크롤러 예약 가능 여부 판별 로직 수정 ([app/crawler/base.py])**
  - 요청한 타임 슬롯 중 단 1분이라도 타인의 예약과 겹친다면, 기존처럼 `unknown`이 아닌 명확하게 `False`(예약 불가)를 반환하도록 공통 로직을 수정했습니다.
- **오픈 대기(`standby_days`) 로직 강화 및 분리 ([app/services/availability_service.py])**
  - 방별로 설정된 '오픈 대기일수' 조건을 룸 조회 초기에 선검사합니다. 예약 오픈 기간이 아닌 방은 무거운 크롤러 API를 호출하지 않고 즉시 `available="unknown"` 상태로 반환하도록 개선했습니다. (응답 속도 향상)
- **최소 요금(`min_price_partial`) 호환성 설계 보존**
  - 룸 상태가 `False`가 되더라도 그 내부에 부분적으로 예약 가능한 빈 슬롯이 남아있다면, 기존처럼 가장 긴 연속 슬롯 블록을 찾아 `min_price_partial`을 계산해 응답에 포함하도록 구현했습니다.
- **프론트엔드 연동 문서 최신화 ([docs/frontend_guide.md])**
  - `unknown` 필드의 의미를 '오픈 대기'로 고지하고, `min_price_partial` 데이터의 작동 방식을 명확히 문서화했습니다.
- **테스트 코드 검증 스펙 전면 수정 (`tests/`)**
  - 부분 예약이 섞여있는 Mock 객체들의 기댓값을 `False`로 변경하고 관련 유닛/통합 테스트들을 전면 수정 및 통과 조치했습니다.

## 2. 체크리스트 (Checklist)
- [x] 관련된 이슈를 PR 커밋 메시지 또는 본문에 링크했습니다. (`#205`)
- [x] PR 제목은 `[#이슈번호]; <태그>: <설명>` 컨벤션을 준수했습니다.
- [x] 새로 작성된 함수와 클래스에는 `Google Style Docstring`(의도, 파라미터 등)이 포함되어 있습니다.
- [x] 테스트 코드가 작성되었거나 기능 테스트가 완료되었습니다.

## 3. 참고 자료 (Optional)
- 프론트엔드 연동 가이드 문서 참조: [docs/frontend_guide.md]
- **[주의점]** 프론트엔드에서는 기존에 `available === 'unknown'` 조건에서 보여주던 부분 예약 카드 UI를, 이제 "예약 대기/오픈 준비 중" 전용 뱃지로 변경하여 대응해주셔야 합니다. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standby-day filtering to pre-filter rooms; crawling separates standby vs active rooms.
  * Partial-availability handling: partial rooms included in results, overnight slot handling, and longest-block pricing applied for partial cases.

* **Bug Fixes**
  * Tri-state availability normalized to booleans for slot values (former "unknown" slots now False) for consistent display and tests.

* **Documentation**
  * Updated availability and pricing descriptions to reflect partial and standby behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->