### PR TITLE
[#197]; feat: GraphQL 필드 확장 및 Apollo State 데이터 수집 보강

### DIFF
--- a/app/crawler/naver_map_crawler.py
+++ b/app/crawler/naver_map_crawler.py
@@ -148,16 +148,24 @@ class NaverMapCrawler:
         return list(results.values())
 
     def _extract_apollo_state_sync(self, page) -> List[Dict]:
-        """window.__APOLLO_STATE__ 변수에서 PlaceSummary 데이터 추출 (Sync version)"""
+        """window.__APOLLO_STATE__ 변수에서 PlaceSummary + 추가 데이터 추출 (Sync version)
+
+        Rationale:
+            PlaceSummary 외에 PlaceDetail(상세설명, 영업시간)과
+            BookingBusiness(예약 메타데이터) 접두사도 수집하여
+            GraphQL 호출 전에 확보 가능한 데이터를 최대화합니다.
+            추가 데이터가 없어도 기존 동작에는 영향 없습니다.
+        """
         return page.evaluate("""
             () => {
                 const state = window.__APOLLO_STATE__;
-                // Debug: Return useful message if state is missing
                 if (!state) {
                      return ["NO_APOLLO_STATE", "URL:" + window.location.href, "BODY_HIDDEN_FOR_SECURITY"];
                 }
                 
                 const places = [];
+                const details = {};    // placeId -> PlaceDetail 필드
+                const bookings = {};   // placeId -> BookingBusiness 필드
                 const keys = Object.keys(state);
                 
                 for (const key of keys) {
@@ -165,6 +173,7 @@ class NaverMapCrawler:
                         const place = state[key];
                         places.push({
                             id: place.bookingBusinessId ?? key.split(':')[1],
+                            placeId: key.split(':')[1],
                             name: place.name,
                             category: place.category,
                             address: place.address,
@@ -172,10 +181,38 @@ class NaverMapCrawler:
                             x: place.x,
                             y: place.y
                         });
+                    } else if (key.startsWith('PlaceDetail:')) {
+                        const d = state[key];
+                        const pid = key.split(':')[1];
+                        details[pid] = {
+                            description: d.description ?? d.desc ?? null,
+                            businessHours: d.businessHours ?? null,
+                            phone: d.phone ?? d.tel ?? null,
+                            homepageUrl: d.homepageUrl ?? null
+                        };
+                    } else if (key.startsWith('BookingBusiness:')) {
+                        const b = state[key];
+                        const bid = key.split(':')[1];
+                        bookings[bid] = {
+                            bookingBusinessId: bid,
+                            bookingUrl: b.bookingUrl ?? null,
+                            businessCategory: b.businessCategory ?? null
+                        };
                     }
                 }
                 
-                // If no places found, return some keys to help debugging
+                // PlaceDetail/BookingBusiness 데이터를 PlaceSummary에 병합 (enrich)
+                for (const place of places) {
+                    const pid = place.placeId;
+                    if (pid && details[pid]) {
+                        Object.assign(place, details[pid]);
+                    }
+                    // bookingBusinessId가 있으면 BookingBusiness 데이터 병합
+                    if (place.id && bookings[place.id]) {
+                        Object.assign(place, bookings[place.id]);
+                    }
+                }
+                
                 if (places.length === 0) {
                     return ["NO_PLACES_FOUND_IN_APOLLO_STATE"];
                 }

--- a/app/crawler/naver_room_fetcher.py
+++ b/app/crawler/naver_room_fetcher.py
@@ -116,6 +116,17 @@ class NaverRoomFetcher:
             bizItemId
             name
             desc
+            stock
+            price
+            minBookingCount
+            maxBookingCount
+            bookingTimeUnitCode
+            minBookingTime
+            maxBookingTime
+            isOnsitePayment
+            bookingCountSettingJson
+            extraFeeSettingJson
+            extraDescJson
             minMaxPrice {
               minPrice
               maxNormalPrice
@@ -123,8 +134,6 @@ class NaverRoomFetcher:
             bizItemResources {
               resourceUrl
             }
-            bookingTimeUnitCode
-            minBookingTime
           }
         }
         """

--- a/app/crawler/naver_room_fetcher.py
+++ b/app/crawler/naver_room_fetcher.py
@@ -68,8 +68,15 @@ class NaverRoomFetcher:
                 businessId
                 name
                 businessDisplayName
+                desc
                 coordinates
                 placeId
+                addressJson
+                phoneInformationJson
+                placeScheduleJson
+                extraDescJson
+                additionalPropertyJson
+                eventDescJson
             }
         }
         """

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -5,7 +5,7 @@ import os
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Any
 from app.crawler.naver_map_crawler import NaverMapCrawler
 from app.crawler.naver_room_fetcher import NaverRoomFetcher
 from app.services.room_parser_service import RoomParserService
@@ -30,7 +30,7 @@ class RoomCollectionService:
         self.parser_service = RoomParserService()
         self.supabase = get_supabase_client()
 
-    async def collect_by_query(self, query: str) -> Dict[str, int]:
+    async def collect_by_query(self, query: str) -> Dict[str, Any]:
         """
         Search and collect rooms by query keyword.
         
@@ -48,19 +48,33 @@ class RoomCollectionService:
         
         success_count = 0
         failed_count = 0
+        failures: List[Dict[str, str]] = []
 
         for item in search_results:
-            business_id = item["id"]
             try:
+                business_id = item.get("id")
+                if not business_id:
+                    raise ValueError("missing business id in search result")
                 await self.collect_by_id(business_id)
                 success_count += 1
             except Exception as e:
-                logger.error(f"Failed to collect {business_id}: {e}")
+                logger.error(f"Failed to collect item={item}: {e}")
                 failed_count += 1
+                failures.append({
+                    "business_id": item.get("id", ""),
+                    "business_name": item.get("name", ""),
+                    "reason": str(e),
+                })
                 
-        return {"success": success_count, "failed": failed_count}
+        return {
+            "query": query,
+            "total": len(search_results),
+            "success": success_count,
+            "failed": failed_count,
+            "failures": failures,
+        }
 
-    async def collect_all_regions(self) -> Dict[str, int]:
+    async def collect_all_regions(self) -> Dict[str, Any]:
         """
         Collect rooms from all major regions nationwide.
         """
@@ -74,20 +88,33 @@ class RoomCollectionService:
         
         success_count = 0
         failed_count = 0
+        failures: List[Dict[str, str]] = []
         
         # 2. Process each found business
         total_items = len(all_items)
         for idx, item in enumerate(all_items):
-            business_id = item["id"]
             try:
+                business_id = item.get("id")
+                if not business_id:
+                    raise ValueError("missing business id in crawl result")
                 logger.info(f"Processing {idx+1}/{total_items}: {item['name']} ({business_id})")
                 await self.collect_by_id(business_id)
                 success_count += 1
             except Exception as e:
-                logger.error(f"Failed to collect {business_id}: {e}")
+                logger.error(f"Failed to collect item={item}: {e}")
                 failed_count += 1
+                failures.append({
+                    "business_id": item.get("id", ""),
+                    "business_name": item.get("name", ""),
+                    "reason": str(e),
+                })
                 
-        return {"success": success_count, "failed": failed_count}
+        return {
+            "total": total_items,
+            "success": success_count,
+            "failed": failed_count,
+            "failures": failures,
+        }
 
     async def collect_by_id(self, business_id: str):
         """Collect and save room information for a specific Business ID."""
@@ -106,12 +133,16 @@ class RoomCollectionService:
             return
 
         # 2. LLM Parsing (Batch with Concurrency)
+        # Rationale: business.desc에 가게 전체 장비/규칙이 담겨 있으므로
+        #            개별 룸 파싱 시 컨텍스트로 함께 전달하여 정확도를 높임
+        business_desc = business.get("desc") or ""
         parse_items = []
         for room in rooms:
             parse_items.append({
                 "id": room["bizItemId"],
                 "name": room["name"],
-                "desc": room.get("desc")
+                "desc": room.get("desc"),
+                "business_desc": business_desc
             })
         
         # Chunk items for parallel processing

--- a/app/services/room_parser_service.py
+++ b/app/services/room_parser_service.py
@@ -78,6 +78,9 @@ Rules:
 - requires_contact_on_sameday: true if "당일" and ("전화" or "문의") found
 - can_reserve_one_hour: false if "최소 2시간", "1시간 예약 불가" found, otherwise true
 
+Business Context (use this to infer missing room details like equipment, capacity):
+{business_context}
+
 Rooms:
 {rooms_text}
 
@@ -494,7 +497,15 @@ class RoomParserService:
                 f"ID: {item['id']}\nName: {item['name']}\nDesc: {item.get('desc') or ''}\n---"
             )
         
-        prompt = BATCH_PARSE_PROMPT.format(rooms_text="\n".join(rooms_text_parts))
+        # business_desc가 있으면 컨텍스트로 사용 (모든 아이템이 동일 가게 소속)
+        business_context = ""
+        if items and items[0].get("business_desc"):
+            business_context = self._clean_text_for_llm(items[0]["business_desc"])
+        
+        prompt = BATCH_PARSE_PROMPT.format(
+            business_context=business_context or "내용 없음",
+            rooms_text="\n".join(rooms_text_parts)
+        )
         
         # Ollama LLM 파싱 시도
         response = await self.ollama_client.generate(prompt, max_tokens=1024)

--- a/tests/crawler/test_naver_map_crawler_apollo_enrichment.py
+++ b/tests/crawler/test_naver_map_crawler_apollo_enrichment.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock
+
+from app.crawler.naver_map_crawler import NaverMapCrawler
+
+
+def test_extract_apollo_state_script_includes_enrichment_prefixes():
+    crawler = NaverMapCrawler(headless=True)
+    page = MagicMock()
+    page.evaluate.return_value = []
+
+    crawler._extract_apollo_state_sync(page)
+
+    script = page.evaluate.call_args.args[0]
+    assert "PlaceSummary:" in script
+    assert "PlaceDetail:" in script
+    assert "BookingBusiness:" in script

--- a/tests/crawler/test_naver_room_fetcher_graphql_fields.py
+++ b/tests/crawler/test_naver_room_fetcher_graphql_fields.py
@@ -1,0 +1,77 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.crawler.naver_room_fetcher import NaverRoomFetcher
+
+
+class _DummyResponse:
+    def __init__(self, data: dict, status_code: int = 200):
+        self._data = data
+        self.status_code = status_code
+        self.text = ""
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._data
+
+
+@pytest.mark.asyncio
+async def test_fetch_business_query_contains_extended_fields():
+    fetcher = NaverRoomFetcher()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _DummyResponse(
+        {
+            "data": {
+                "business": {
+                    "businessId": "522011",
+                    "coordinates": [127.0, 37.0],
+                }
+            }
+        }
+    )
+
+    await fetcher._fetch_business(mock_client, "522011")
+
+    payload = mock_client.post.await_args.kwargs["json"]
+    query = payload["query"]
+
+    required_fields = [
+        "desc",
+        "addressJson",
+        "phoneInformationJson",
+        "placeScheduleJson",
+        "extraDescJson",
+        "additionalPropertyJson",
+        "eventDescJson",
+    ]
+    for field in required_fields:
+        assert field in query
+
+
+@pytest.mark.asyncio
+async def test_fetch_biz_items_query_contains_extended_fields():
+    fetcher = NaverRoomFetcher()
+    mock_client = AsyncMock()
+    mock_client.post.return_value = _DummyResponse({"data": {"bizItems": []}})
+
+    await fetcher._fetch_biz_items(mock_client, "522011")
+
+    payload = mock_client.post.await_args.kwargs["json"]
+    query = payload["query"]
+
+    required_fields = [
+        "stock",
+        "minBookingCount",
+        "maxBookingCount",
+        "minBookingTime",
+        "maxBookingTime",
+        "isOnsitePayment",
+        "bookingCountSettingJson",
+        "extraFeeSettingJson",
+        "extraDescJson",
+    ]
+    for field in required_fields:
+        assert field in query

--- a/tests/services/test_room_collection_business_context.py
+++ b/tests/services/test_room_collection_business_context.py
@@ -1,0 +1,48 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_collect_by_id_passes_business_desc_to_parser_batch():
+    with patch("app.services.room_collection_service.NaverMapCrawler"), patch(
+        "app.services.room_collection_service.NaverRoomFetcher"
+    ), patch("app.services.room_collection_service.RoomParserService"), patch(
+        "app.services.room_collection_service.get_supabase_client"
+    ):
+        from app.services.room_collection_service import RoomCollectionService
+
+        service = RoomCollectionService()
+
+    service.room_fetcher.fetch_full_info = AsyncMock(
+        return_value={
+            "business": {
+                "businessId": "522011",
+                "businessDisplayName": "Test Studio",
+                "desc": "Store-wide context for equipment and rules",
+                "coordinates": {"latitude": 37.0, "longitude": 127.0},
+            },
+            "rooms": [
+                {"bizItemId": "room-1", "name": "Room A", "desc": "Max 6"},
+            ],
+            "subway": None,
+        }
+    )
+    service.parser_service.parse_room_desc_batch = AsyncMock(
+        return_value={
+            "room-1": {
+                "clean_name": "Room A",
+                "max_capacity": 6,
+                "recommend_capacity": 4,
+            }
+        }
+    )
+    service._save_to_db = AsyncMock()
+    service._export_unresolved = AsyncMock()
+
+    await service.collect_by_id("522011")
+
+    parse_items = service.parser_service.parse_room_desc_batch.await_args.args[0]
+    assert len(parse_items) == 1
+    assert parse_items[0]["id"] == "room-1"
+    assert parse_items[0]["business_desc"] == "Store-wide context for equipment and rules"

--- a/tests/services/test_room_parser_batch_context.py
+++ b/tests/services/test_room_parser_batch_context.py
@@ -1,0 +1,27 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.room_parser_service import RoomParserService
+
+
+@pytest.mark.asyncio
+async def test_batch_prompt_includes_business_context():
+    mock_client = MagicMock()
+    mock_client.generate = AsyncMock(return_value=None)
+    parser = RoomParserService(ollama_client=mock_client)
+
+    await parser.parse_room_desc_batch(
+        [
+            {
+                "id": "room-1",
+                "name": "Room A",
+                "desc": "Max 6",
+                "business_desc": "Store-wide context for equipment and rules",
+            }
+        ]
+    )
+
+    prompt = mock_client.generate.await_args.args[0]
+    assert "Business Context" in prompt
+    assert "Store-wide context for equipment and rules" in prompt


### PR DESCRIPTION
## 0. 도입 배경 (Background)

네이버 지도의 합주실 데이터 수집 시, 기존 룸 딕셔너리에만 의존하던 파생 정보(예: 매장 설명, 환불 규정 등)를 더 풍부하게 가져오기 위해 GraphQL 쿼리 필드를 확장하고 Apollo State의 초기 데이터를 긁어옵니다.

이 변경은 향후 진행될 **규칙 기반 룸 파서 고도화(Phase 3)**를 위한 기반 데이터 계층(Data Layer) 작업입니다.

## 1. 주요 변경 사항

- **GraphQL bizItems 확장**: \usiness\ 필드를 쿼리에 추가 요청하여 기본 메타데이터 보강
- **Apollo State 추출**: \PlaceDetail\, \BookingBusiness\ 상태 트리를 파싱해 초기 로딩 데이터 획득
- **비즈니스 컨텍스트 전달**: 매장의 전역 설명(\desc\) 등을 룸 파싱 시 활용하도록 컨텍스트 파라미터 연동

## 2. 리뷰어 참고 사항

- 이 PR은 순수하게 수집하는 데이터 원천을 늘리고, 서비스 계층으로 내려주는 인자(signature)만 추가한 상태입니다.
- 파서 자체의 로직 개편은 다음 PR에서 이어서 진행됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded data collection to include detailed place information such as descriptions, business hours, contact details, and booking information.
  * Enhanced error reporting with specific failure details and business identifiers for improved troubleshooting.
  * Improved room parsing accuracy by incorporating business context information.

* **Tests**
  * Added test coverage for extended data field collection and business context propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->