### PR TITLE
[#239] fix: 권장 인원 범위 단일값 반환 버그 수정

### DIFF
--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -36,30 +36,32 @@ class RoomCollectionService:
     # - 10,000~14,999 KRW -> 4~5 people
     # - 15,000~19,999 KRW -> 7~8 people
     # - 20,000+ KRW -> 10+ people
+    # max_capacity 규칙: recommend_range 상한 + 3 이상
+    # recommend < 9 → ±1, recommend >= 9 → ±2
     PRICE_BAND_CAPACITY_DEFAULTS: List[Dict[str, Any]] = [
         {
             "name": "10k_15k",
             "min_price": 10000,
             "max_price": 14999,
-            "max_capacity": 5,
+            "max_capacity": 8,
             "recommend_capacity": 4,
-            "recommend_range": [4, 4],
+            "recommend_range": [3, 5],
         },
         {
             "name": "15k_20k",
             "min_price": 15000,
             "max_price": 19999,
-            "max_capacity": 8,
+            "max_capacity": 11,
             "recommend_capacity": 7,
-            "recommend_range": [7, 7],
+            "recommend_range": [6, 8],
         },
         {
             "name": "20k_plus",
             "min_price": 20000,
             "max_price": None,  # open upper bound
-            "max_capacity": 11,
+            "max_capacity": 15,
             "recommend_capacity": 10,
-            "recommend_range": [10, 11],
+            "recommend_range": [8, 12],
         },
     ]
     PRICE_CAPACITY_RULES: Dict[str, List[Dict[str, Any]]] = {
@@ -1119,7 +1121,8 @@ class RoomCollectionService:
                 and len(default_range) == 2
                 and all(isinstance(v, int) for v in default_range)
             ):
-                default_range = [max(default_rec - 1, 1), min(default_rec + 1, default_max)]
+                delta = 2 if default_rec >= 9 else 1
+                default_range = [max(default_rec - delta, 1), min(default_rec + delta, default_max)]
 
             rec_cap = default_rec
             rec_range = default_range
@@ -1507,7 +1510,7 @@ class RoomCollectionService:
         if pair_match:
             rec = int(pair_match.group(1))
             max_cap = int(pair_match.group(2))
-            return max_cap, rec, [rec, rec]
+            return max_cap, rec, None
 
         rec_cap: Optional[int] = None
         max_cap: Optional[int] = None
@@ -1525,8 +1528,6 @@ class RoomCollectionService:
         rec_match = re.search(r"정원\s*(\d+)\s*명", text)
         if rec_match:
             rec_cap = int(rec_match.group(1))
-            if rec_range is None:
-                rec_range = [rec_cap, rec_cap]
 
         max_match = re.search(r"최대\s*(\d+)\s*명", text)
         if max_match:
@@ -1856,13 +1857,12 @@ class RoomCollectionService:
             return [base_cap, real_max]
             
         # 3. 추가 요금 없는 경우 (기본)
-        # min: rec_cap, max: rec_cap + 2
-        # 단 max_cap을 넘지 않도록 제한
-        min_c = rec_cap
-        max_c = min(rec_cap + 2, max_cap)
-        
-        # 만약 rec_cap + 2 > max_cap 이라면 max_c가 min_c보다 작아지는 경우 방어
-        # (예: rec=5, max=5 -> min=5, max=5)
+        # recommend < 9 → ±1, recommend >= 9 → ±2
+        delta = 2 if rec_cap >= 9 else 1
+        min_c = max(rec_cap - delta, 1)
+        max_c = min(rec_cap + delta, max_cap) if max_cap > 0 else rec_cap + delta
+
+        # min <= max 보장
         max_c = max(max_c, min_c)
         
         return [min_c, max_c]

--- a/app/services/room_parser_service.py
+++ b/app/services/room_parser_service.py
@@ -110,8 +110,6 @@ class RoomParserService:
             can_reserve_1h = False
 
         rec_range = parsed_range
-        if not rec_range and rec_cap:
-            rec_range = [rec_cap, rec_cap]
 
         def _map_day_type(keyword: Optional[str]) -> str:
             if keyword == "평일":

--- a/tests/integration/test_room_collection_flow.py
+++ b/tests/integration/test_room_collection_flow.py
@@ -56,7 +56,7 @@ class TestCollectByIdFlow:
                 "day_type": "weekday",
                 "max_capacity": 6,
                 "recommend_capacity": 4,
-                "recommend_capacity_range": [4, 4],
+                "recommend_capacity_range": None,
                 "base_capacity": 4,
                 "extra_charge": 3000,
                 "price_config": [{"days": [0, 1, 2, 3, 4], "price": 15000}],
@@ -144,7 +144,7 @@ class TestCollectByIdFlow:
         assert room1_data["extra_charge"] == 3000
         assert len(room1_data["image_urls"]) == 2
         # [v2.0.0] 신규 필드 검증
-        assert room1_data["recommend_capacity_range"] == [4, 4]
+        assert room1_data["recommend_capacity_range"] == [4, 6]
         assert room1_data["price_config"] == [{"days": [0, 1, 2, 3, 4], "price": 15000}]
     
     # ============== IT03: Fetcher 실패 시 예외 ==============

--- a/tests/services/test_room_collection_price_inference.py
+++ b/tests/services/test_room_collection_price_inference.py
@@ -148,9 +148,9 @@ async def test_price_band_fallback_applied_for_unknown_business_in_10k_15k_band(
 
     upsert_call = mock_supabase._room_table.upsert.call_args_list[-1]
     room_data = upsert_call[0][0]
-    assert room_data["max_capacity"] == 5
+    assert room_data["max_capacity"] == 8
     assert room_data["recommend_capacity"] == 4
-    assert room_data["recommend_capacity_range"] == [4, 4]
+    assert room_data["recommend_capacity_range"] == [3, 5]
 
 
 @pytest.mark.asyncio
@@ -174,9 +174,9 @@ async def test_price_band_fallback_applied_for_unknown_business_in_15k_20k_band(
 
     upsert_call = mock_supabase._room_table.upsert.call_args_list[-1]
     room_data = upsert_call[0][0]
-    assert room_data["max_capacity"] == 8
+    assert room_data["max_capacity"] == 11
     assert room_data["recommend_capacity"] == 7
-    assert room_data["recommend_capacity_range"] == [7, 7]
+    assert room_data["recommend_capacity_range"] == [6, 8]
 
 
 @pytest.mark.asyncio
@@ -200,6 +200,6 @@ async def test_price_band_fallback_applied_for_unknown_business_in_20k_plus_band
 
     upsert_call = mock_supabase._room_table.upsert.call_args_list[-1]
     room_data = upsert_call[0][0]
-    assert room_data["max_capacity"] == 11
+    assert room_data["max_capacity"] == 15
     assert room_data["recommend_capacity"] == 10
-    assert room_data["recommend_capacity_range"] == [10, 11]
+    assert room_data["recommend_capacity_range"] == [8, 12]

--- a/tests/services/test_room_collection_service.py
+++ b/tests/services/test_room_collection_service.py
@@ -362,13 +362,14 @@ class TestV2NewFields:
         assert room_data["recommend_capacity_range"] == [4, 6]
         assert room_data["price_config"] == []
     
-    # ============== TC: range 없으면 [n, n] Fallback ==============
+    # ============== TC: range 없으면 ±1/±2 Fallback ==============
     @pytest.mark.asyncio
     async def test_fallback_range_from_single_capacity(self, service, mock_supabase):
         """파서가 범위를 반환하지 않으면 규칙 기반으로 계산
-        
+
         Rationale:
-            extra_charge=None → [rec_cap, min(rec_cap+2, max_cap)] = [4, 6]
+            recommend < 9 → ±1, recommend >= 9 → ±2
+            rec=4, price=10000 → price band(10k_15k) 적용 → rec=4, ±1 → [3, 5]
         """
         business = {"businessId": "biz1", "businessDisplayName": "테스트", "coordinates": None}
         rooms = [{"bizItemId": "r1", "name": "룸A", "bizItemResources": [], "minMaxPrice": {"minPrice": 10000}}]
@@ -382,14 +383,14 @@ class TestV2NewFields:
                 "requires_contact_on_sameday": False
             }
         }
-        
+
         await service._save_to_db(business, rooms, parsed_results)
-        
+
         upsert_call = mock_supabase._room_table.upsert.call_args_list[-1]
         room_data = upsert_call[0][0]
-        
-        # NOTE: 규칙 기반 → [4, min(6, 6)] = [4, 6]
-        assert room_data["recommend_capacity_range"] == [4, 6]
+
+        # rec=4 (<9) → ±1 → [3, 5]
+        assert room_data["recommend_capacity_range"] == [3, 5]
     
     # ============== TC: display_name 및 standby_days 저장 ==============
     @pytest.mark.asyncio
@@ -428,7 +429,7 @@ class TestV2NewFields:
             "r1": {
                 "max_capacity": 6,
                 "recommend_capacity": 4,
-                "recommend_capacity_range": [4, 4],
+                "recommend_capacity_range": None,
                 "price_config": price_cfg,
                 "base_capacity": None,
                 "extra_charge": None,


### PR DESCRIPTION
## Summary
- `recommend_capacity_range`가 `[N, N]` 단일값으로 저장되던 버그 수정
- 권장 범위 규칙 도입: `recommend < 9` → ±1, `recommend >= 9` → ±2
- `max_capacity`를 권장 범위 상한 + 3 이상으로 조정하여 clamp 방지
- `_calculate_capacity_range` 고정 +2 → ±delta 대칭 범위로 변경
- `MIN_REHEARSAL_PRICE`(7,000원) 미만 룸 수집 제외 필터 추가
- `REHEARSAL_KEYWORDS`에서 개인연습실 키워드(음악연습실, 악기연습실, 드럼연습실) 제거

## 변경 내역
- `room_parser_service.py`: 범위 미확정 시 `[N, N]` 대신 `None` 반환
- `room_collection_service.py`:
  - `_extract_capacity_text_signals`: `[rec, rec]` fallback 제거
  - `PRICE_BAND_CAPACITY_DEFAULTS`: ±1/±2 규칙 적용 + max_capacity 상향
  - `_infer_capacity_from_price` fallback: 동일 규칙 적용
  - `_calculate_capacity_range`: 고정 +2 → rec_cap ±delta (< 9: ±1, >= 9: ±2)
  - `MIN_REHEARSAL_PRICE = 7000` 상수 추가, `_has_reservation_metadata`에서 최소 가격 필터 적용
  - `REHEARSAL_KEYWORDS`에서 개인연습실 키워드 제거
- `tests/services/test_room_collection_service.py`:
  - fallback 범위 테스트 기대값 수정 (`[4,6]` → `[3,5]`)
  - delta 경계값 parametrize 테스트 5케이스 추가 (rec=1,5,8,9,10)

## Test plan
- [x] 전체 테스트 355 passed, 4 skipped
- [x] delta 경계값 테스트 (rec=8 → [7,9], rec=9 → [7,11]) 통과
- [ ] 가격대별 범위 확인 (10k: [3,5], 15k: [6,8], 20k+: [8,12])
- [ ] 파서에서 명시적 범위("4~6명") 있을 때 그대로 통과 확인
- [ ] 추가요금 있는 룸에서 [base_cap, max_cap] 범위 정상 확인
- [ ] 7,000원 미만 룸이 수집에서 제외되는지 확인

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)