### PR TITLE
[#247]; fix: 드림합주실 슬롯 파싱 시 종료 시간 오매칭 버그 수정

### DIFF
--- a/app/crawler/dream_checker.py
+++ b/app/crawler/dream_checker.py
@@ -1,10 +1,10 @@
-from app.exception.crawler.dream_exception import DreamRequestError
-from bs4 import BeautifulSoup
 import html
-import sys
 import asyncio
+import logging
 from datetime import datetime
 from typing import List
+
+from bs4 import BeautifulSoup
 
 from app.models.dto import RoomDetail, RoomAvailability
 from app.utils.client_loader import load_client
@@ -14,12 +14,15 @@ from app.exception.crawler.dream_exception import DreamAvailabilityError
 from app.crawler.base import BaseCrawler, RoomResult
 from app.crawler.registry import registry
 
+logger = logging.getLogger("app")
+
+
 class DreamCrawler(BaseCrawler):
     """드림 합주실의 예약 가능 여부를 확인하는 전용 크롤러.
-    
-    드림 합주실은 네이버 예약을 사용하지 않고 자체 웹사이트 예약 폼(wz.bookingT1)을 
+
+    드림 합주실은 네이버 예약을 사용하지 않고 자체 웹사이트 예약 폼(wz.bookingT1)을
     사용하므로, 직접 HTTP POST 요청을 통해 예약 정보를 스크래핑합니다.
-    
+
     Rationale (의도):
         - 네이버 크롤러와 동일한 BaseCrawler 인터페이스를 구현하여, AvailabilityService에서
           합주실 타입(지점)을 몰라도 다형성으로 일괄 처리할 수 있게 함.
@@ -32,20 +35,31 @@ class DreamCrawler(BaseCrawler):
     }
     DATE_LIMIT_DAYS = 121  # Reservation window limit per Dream policy.
 
+    @staticmethod
+    def _to_dream_time_str(hour_slot: str) -> str:
+        """'14:00' → '14시00분' (드림 API title prefix 형식)
+
+        Rationale:
+            f"{int(...):02d}" 로 제로패딩을 명시적으로 보장함.
+            hour_slots가 항상 두 자리("09:00")로 전달되더라도, 변환 책임을 한 곳에서 관리해
+            API 포맷 변경 시 수정 지점이 분산되지 않도록 함.
+        """
+        return f"{int(hour_slot.split(':')[0]):02d}시00분"
+
     async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail]) -> List[RoomResult]:
         """드림 합주실의 특정 날짜와 시간대에 예약 가능한 방들을 조회합니다.
-        
+
         Args:
             date (str): 조회할 날짜 (예: '2026-05-20')
             hour_slots (List[str]): 1시간 단위 시간 슬롯 배열 (예: ['14:00', '15:00'])
             target_rooms (List[RoomDetail]): 합주실 방 정보 리스트 (용량/지점 필터링이 완료된 상태)
-            
+
         Returns:
             List[RoomResult]: 방별 예약 가능 여부(RoomAvailability) 또는 에러(Exception) 객체 배열
-            
+
         Rationale (의도):
             - 여러 방에 대한 조회를 순차로 하면 I/O 대기시간이 길어지므로 asyncio.gather로 병렬 처리.
-            - 개별 방 조회가 500 에러를 뿜더라도, 안전하게 Exception 객체로 잡아내어 
+            - 개별 방 조회가 500 에러를 뿜더라도, 안전하게 Exception 객체로 잡아내어
               살아남은 다른 방의 조회 결과를 프론트로 전달할 수 있도록 safe_fetch 처리.
         """
         today = datetime.strptime(datetime.now().strftime('%Y-%m-%d'), '%Y-%m-%d').date()
@@ -117,27 +131,37 @@ class DreamCrawler(BaseCrawler):
         )
 
     def _parse_html_content(self, items_html: str, hour_slots: List[str]) -> dict:
-        """BeautifulSoup을 사용하여 HTML에서 시간대별 예약 가능 여부를 파싱합니다."""
+        """BeautifulSoup을 사용하여 HTML에서 시간대별 예약 가능 여부를 파싱합니다.
+
+        드림 API title 형식: "22시00분 ~ 23시00분  최대 15명 예약가능" (예약 가능)
+                             "21시00분 ~ 22시00분 예약마감"            (예약 마감)
+        title은 항상 시작 시간으로 시작하므로 startswith으로 매칭함.
+        """
         soup = BeautifulSoup(items_html, "lxml")
         available_slots = {}
 
         for time in hour_slots:
-            target_time = time.split(":")[0] + "시00분"  # 예: "14:00" -> "14시00분"
+            # P0: 제로패딩 보장 + P1: 변환 책임을 _to_dream_time_str에 위임
+            target_time = self._to_dream_time_str(time)
 
-            # title 속성이 target_time으로 시작하는 label 태그 찾기
-            # 실제 드림 API title 형식: "22시00분 ~ 23시00분  최대 15명 예약가능"
-            # 주의: `target_time in t` 사용 시 이전 슬롯의 종료 시간에도 매칭됨
-            # (예: "21시00분 ~ 22시00분 예약마감" 에서 "22시00분" 검색 시 잘못 매칭)
-            label = soup.find('label', title=lambda t: t and isinstance(t, str) and t.startswith(target_time))
+            # P0 lambda loop-capture 방지: default argument binding으로 target_time을 즉시 고정
+            # (현재는 soup.find가 즉시 평가하므로 실질적 버그 없으나, 리팩토링 안전성을 위해 선제 적용)
+            label = soup.find(
+                'label',
+                title=lambda t, tt=target_time: isinstance(t, str) and t.startswith(tt)
+            )
 
             if label:
-                # class 속성에 'active'가 있으면 예약 가능
                 classes = label.get("class", [])
                 available_slots[time] = "active" in classes
             else:
+                logger.warning(
+                    f"[DreamCrawler] {time} 슬롯 label 미발견 — API 응답 HTML에 해당 시간 없음"
+                )
                 available_slots[time] = False
 
         return available_slots
+
 
 # Register the crawler
 registry.register("dream", DreamCrawler())

--- a/app/crawler/dream_checker.py
+++ b/app/crawler/dream_checker.py
@@ -124,9 +124,11 @@ class DreamCrawler(BaseCrawler):
         for time in hour_slots:
             target_time = time.split(":")[0] + "시00분"  # 예: "14:00" -> "14시00분"
 
-            # title 속성에 target_time이 포함된 label 태그 찾기
-            # 예: title="2024-05-20 14시00분 (월)"
-            label = soup.find('label', title=lambda t: t and isinstance(t, str) and target_time in t)
+            # title 속성이 target_time으로 시작하는 label 태그 찾기
+            # 실제 드림 API title 형식: "22시00분 ~ 23시00분  최대 15명 예약가능"
+            # 주의: `target_time in t` 사용 시 이전 슬롯의 종료 시간에도 매칭됨
+            # (예: "21시00분 ~ 22시00분 예약마감" 에서 "22시00분" 검색 시 잘못 매칭)
+            label = soup.find('label', title=lambda t: t and isinstance(t, str) and t.startswith(target_time))
 
             if label:
                 # class 속성에 'active'가 있으면 예약 가능

--- a/tests/test_dream_checker.py
+++ b/tests/test_dream_checker.py
@@ -41,20 +41,27 @@ def sample_dream_rooms():
     return rooms
 
 
-def _make_mock_response(available_times: list[str], date: str):
+def _make_mock_response(
+    available_times: list[str],
+    date: str,
+    inactive_times: list[str] | None = None,
+):
     """드림 연습실 API 응답을 모방하는 Mock Response 생성 헬퍼
 
     Args:
         available_times: 예약 가능한 시간 목록 (예: ["13시00분", "14시00분"])
         date: 대상 날짜 (예: "2026-02-14", 현재는 title에 사용되지 않음)
+        inactive_times: 예약 마감으로 렌더링할 시간 목록 (예: ["14시00분"])
+            None이면 마감 label을 생성하지 않음 (label 자체가 없는 경우를 재현).
+            실제 API는 예약 마감 시간도 btn-time(active 없음) label로 포함하므로,
+            파싱 로직의 "label 있음 + active 없음 → False" 경로를 테스트하려면 전달.
 
     Rationale:
         실제 드림 연습실 API는 JSON 내 'items' 키에 HTML 문자열을 반환함.
         BeautifulSoup 파싱 로직까지 검증하기 위해 실제 응답 구조를 모방.
 
-        실제 title 형식: "22시00분 ~ 23시00분  최대 15명 예약가능"
-        파싱 로직은 t.startswith(target_time)으로 시작 시간을 기준으로 매칭하므로
-        title이 반드시 해당 시간으로 시작해야 함.
+        실제 title 형식: "22시00분 ~ 23시00분  최대 15명 예약가능" (active)
+                         "21시00분 ~ 22시00분 예약마감"            (inactive)
     """
     def _next_hour(time_str: str) -> str:
         """"13시00분" -> "14시00분" (24시 -> "00시00분")"""
@@ -66,6 +73,12 @@ def _make_mock_response(available_times: list[str], date: str):
         next_time = _next_hour(time_str)
         labels += (
             f'<label class="btn-time active" title="{time_str} ~ {next_time}  최대 15명 예약가능">'
+            f'{time_str}</label>\n'
+        )
+    for time_str in (inactive_times or []):
+        next_time = _next_hour(time_str)
+        labels += (
+            f'<label class="btn-time " title="{time_str} ~ {next_time} 예약마감">'
             f'{time_str}</label>\n'
         )
     mock_resp = MagicMock()
@@ -103,8 +116,9 @@ async def test_dream_partial_availability(sample_dream_rooms):
     hour_slots = ["13:00", "14:00"]
     crawler = DreamCrawler()
 
-    # NOTE: 13시만 가능, 14시는 불가능한 응답
-    mock_response = _make_mock_response(["13시00분"], date)
+    # NOTE: 13시만 가능, 14시는 마감 — 실제 API처럼 inactive label도 포함하여
+    #       "label 있음 + active 없음 → False" 경로를 검증
+    mock_response = _make_mock_response(["13시00분"], date, inactive_times=["14시00분"])
 
     with patch("app.crawler.dream_checker.load_client", new_callable=AsyncMock, return_value=mock_response):
         result = await crawler.check_availability(date, hour_slots, sample_dream_rooms[:1])

--- a/tests/test_dream_checker.py
+++ b/tests/test_dream_checker.py
@@ -46,16 +46,26 @@ def _make_mock_response(available_times: list[str], date: str):
 
     Args:
         available_times: 예약 가능한 시간 목록 (예: ["13시00분", "14시00분"])
-        date: 대상 날짜 (예: "2026-02-14")
+        date: 대상 날짜 (예: "2026-02-14", 현재는 title에 사용되지 않음)
 
     Rationale:
         실제 드림 연습실 API는 JSON 내 'items' 키에 HTML 문자열을 반환함.
         BeautifulSoup 파싱 로직까지 검증하기 위해 실제 응답 구조를 모방.
+
+        실제 title 형식: "22시00분 ~ 23시00분  최대 15명 예약가능"
+        파싱 로직은 t.startswith(target_time)으로 시작 시간을 기준으로 매칭하므로
+        title이 반드시 해당 시간으로 시작해야 함.
     """
+    def _next_hour(time_str: str) -> str:
+        """"13시00분" -> "14시00분" (24시 -> "00시00분")"""
+        hour = int(time_str.replace("시00분", ""))
+        return f"{(hour + 1) % 24:02d}시00분"
+
     labels = ""
     for time_str in available_times:
+        next_time = _next_hour(time_str)
         labels += (
-            f'<label class="active" title="{date} {time_str} (월)">'
+            f'<label class="btn-time active" title="{time_str} ~ {next_time}  최대 15명 예약가능">'
             f'{time_str}</label>\n'
         )
     mock_resp = MagicMock()

--- a/tests/test_dream_checker_parsing.py
+++ b/tests/test_dream_checker_parsing.py
@@ -4,13 +4,16 @@ from app.crawler.dream_checker import DreamCrawler
 # 테스트용 크롤러 인스턴스 생성
 crawler = DreamCrawler()
 
+# 실제 드림 API title 형식: "22시00분 ~ 23시00분  최대 15명 예약가능" (가능)
+#                           "21시00분 ~ 22시00분 예약마감"            (마감)
+
 def test_parse_available_slot():
     """active 클래스가 있는 경우 예약 가능으로 판단되는지 테스트"""
     mock_html = """
-    <div>
-        <label title="2024-05-20 14시00분 (월)" class="time active">14:00</label>
-        <label title="2024-05-20 15시00분 (월)" class="time">15:00</label>
-    </div>
+    <ul>
+        <li><label class="btn-time active" title="14시00분 ~ 15시00분  최대 15명 예약가능">14:00 ~ 15:00</label></li>
+        <li><label class="btn-time " title="15시00분 ~ 16시00분 예약마감">15:00 ~ 16:00 (예약마감)</label></li>
+    </ul>
     """
     hour_slots = ["14:00", "15:00"]
 
@@ -21,7 +24,7 @@ def test_parse_available_slot():
 
 def test_parse_unavailable_slot():
     """active 클래스가 없는 경우 예약 불가능으로 판단되는지 테스트"""
-    mock_html = '<label title="2024-05-20 14시00분 (월)" class="time">14:00</label>'
+    mock_html = '<label class="btn-time " title="14시00분 ~ 15시00분 예약마감">14:00 ~ 15:00 (예약마감)</label>'
     hour_slots = ["14:00"]
 
     result = crawler._parse_html_content(mock_html, hour_slots)
@@ -30,8 +33,8 @@ def test_parse_unavailable_slot():
 
 def test_parse_missing_label():
     """해당 시간대의 label이 없으면 False 반환하는지 테스트"""
-    mock_html = '<label title="2024-05-20 18시00분 (월)" class="time active">18:00</label>'
-    hour_slots = ["14:00"] # 14시 라벨 없음
+    mock_html = '<label class="btn-time active" title="18시00분 ~ 19시00분  최대 15명 예약가능">18:00 ~ 19:00</label>'
+    hour_slots = ["14:00"]  # 14시 라벨 없음
 
     result = crawler._parse_html_content(mock_html, hour_slots)
 
@@ -40,9 +43,34 @@ def test_parse_missing_label():
 def test_parse_broken_html():
     """깨진 HTML에서도 lxml이 최선으로 파싱하여 동작하는지 확인"""
     # 닫는 태그 누락 등
-    mock_html = '<label title="2024-05-20 14시00분 (월)" class="time active">14:00'
+    mock_html = '<label class="btn-time active" title="14시00분 ~ 15시00분  최대 15명 예약가능">14:00'
     hour_slots = ["14:00"]
 
     result = crawler._parse_html_content(mock_html, hour_slots)
 
     assert result["14:00"] is True
+
+def test_parse_end_time_not_matched_as_start():
+    """이전 슬롯의 종료 시간이 다음 슬롯의 시작 시간으로 오인되지 않는지 테스트 (회귀)
+
+    버그 재현 시나리오:
+      - 21:00 슬롯: title="21시00분 ~ 22시00분 예약마감" (active 없음)
+      - 22:00 슬롯: title="22시00분 ~ 23시00분  최대 15명 예약가능" (active 있음)
+
+    `target_time in t` 검색 시, "22시00분"이 21:00 슬롯 title에도 포함되어
+    첫 매칭이 21:00 슬롯(active 없음) → 잘못된 False 반환.
+    `t.startswith(target_time)` 으로 수정 후 22:00 슬롯을 정확히 매칭해야 함.
+    """
+    mock_html = """
+    <ul>
+        <li><label class="btn-time " title="21시00분 ~ 22시00분 예약마감">21:00 ~ 22:00 (예약마감)</label></li>
+        <li><label class="btn-time active" title="22시00분 ~ 23시00분  최대 15명 예약가능">22:00 ~ 23:00</label></li>
+        <li><label class="btn-time active" title="23시00분 ~ 00시00분  최대 15명 예약가능">23:00 ~ 00:00</label></li>
+    </ul>
+    """
+    hour_slots = ["22:00", "23:00"]
+
+    result = crawler._parse_html_content(mock_html, hour_slots)
+
+    assert result["22:00"] is True, "22:00은 active 슬롯이므로 True여야 함 (이전 슬롯 종료 시간에 오인 매칭 시 False)"
+    assert result["23:00"] is True


### PR DESCRIPTION
Closes #247 
## 버그 원인

  `_parse_html_content`에서 label을 찾을 때 `target_time in title` 조건을 사용하고 있었음.

  드림합주실 API의 실제 title 형식은 시작~종료 시간을 모두 포함:
    "21시00분 ~ 22시00분 예약마감"            ← 21:00 슬롯
    "22시00분 ~ 23시00분  최대 15명 예약가능"  ← 22:00 슬롯

  "22시00분"을 검색하면 21:00 슬롯의 title에서 종료 시간으로 먼저 매칭 →
  해당 label은 active 클래스 없음 → 실제 예약 가능한 22:00 슬롯이 False로 잘못 파싱됨.

  ## 수정 내용

  - `app/crawler/dream_checker.py`: `target_time in t` → `t.startswith(target_time)`
    드림 API title은 항상 시작 시간으로 시작하므로 startswith으로 정확히 매칭.

  - `tests/test_dream_checker_parsing.py`: mock HTML title 형식을 실제 드림 API 형식으로 교정,
    회귀 테스트(test_parse_end_time_not_matched_as_start) 추가.

  - `tests/test_dream_checker.py`: `_make_mock_response` title 형식 교정
    - 기존: "{date} 13시00분 (월)"
    - 수정: "13시00분 ~ 14시00분  최대 15명 예약가능"

  ## 테스트

  366 passed, 4 skipped

  ---
  전체 결과 요약:
  - 브랜치: bug/247-dream-slot-starttime-match (로컬/원격 모두 완료)
  - 변경: dream_checker.py 1줄, 테스트 2파일 형식 교정 + 회귀 테스트 추가
  - 테스트: 366 passed ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time-slot matching to avoid false positives between slot end-times and next slot start-times, fixing availability detection.
  * Added handling for titles formatted with explicit time ranges.

* **Tests**
  * Expanded and adjusted tests to cover active/inactive slot states and the corrected matching logic.

* **Documentation**
  * Updated docstrings and comments to reflect new time-string handling and matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->