### PR TITLE
fix: capacity 필드 이상값 방어 로직 및 DB 정리 스크립트

### DIFF
--- a/app/models/dto.py
+++ b/app/models/dto.py
@@ -126,6 +126,16 @@ class RoomDetail(BaseModel):
         ):
             self.recommendCapacityRange = None
 
+        # [#257] 레거시 sentinel clamp(100→50) 잔재 및 상한 초과 방어
+        if self.recommendCapacityRange and len(self.recommendCapacityRange) == 2:
+            lo, hi = self.recommendCapacityRange
+            # [50,50]: MANUAL_REVIEW_FLAG(100)이 50으로 clamp된 레거시 산물
+            if lo == 50 and hi == 50:
+                self.recommendCapacityRange = None
+            # 상한이 max_capacity 초과: max_capacity 기준으로 clamp
+            elif self.maxCapacity > 0 and hi > self.maxCapacity:
+                self.recommendCapacityRange = [min(lo, self.maxCapacity), self.maxCapacity]
+
         if self.maxCapacity == self.MANUAL_REVIEW_CAPACITY_FLAG:
             self.maxCapacity = 0
 

--- a/app/models/dto.py
+++ b/app/models/dto.py
@@ -132,9 +132,9 @@ class RoomDetail(BaseModel):
             # [50,50]: MANUAL_REVIEW_FLAG(100)이 50으로 clamp된 레거시 산물
             if lo == 50 and hi == 50:
                 self.recommendCapacityRange = None
-            # 상한이 max_capacity 초과: max_capacity 기준으로 clamp
+            # 상한이 max_capacity 초과: max_capacity 기준으로 clamp, 하한 최솟값 1 보장
             elif self.maxCapacity > 0 and hi > self.maxCapacity:
-                self.recommendCapacityRange = [min(lo, self.maxCapacity), self.maxCapacity]
+                self.recommendCapacityRange = [max(1, min(lo, self.maxCapacity)), self.maxCapacity]
 
         if self.maxCapacity == self.MANUAL_REVIEW_CAPACITY_FLAG:
             self.maxCapacity = 0

--- a/app/models/dto.py
+++ b/app/models/dto.py
@@ -118,6 +118,11 @@ class RoomDetail(BaseModel):
     @model_validator(mode="after")
     def populate_v2_fields(self) -> "RoomDetail":
         """V2 호환 필드를 채우고 수동검토 플래그 값을 안전한 응답값으로 변환"""
+        # ① maxCapacity FLAG를 먼저 0으로 변환 — 이후 range clamp의 기준값으로 사용
+        if self.maxCapacity == self.MANUAL_REVIEW_CAPACITY_FLAG:
+            self.maxCapacity = 0
+
+        # ② [100,100] → None
         if (
             self.recommendCapacityRange
             and len(self.recommendCapacityRange) == 2
@@ -126,7 +131,7 @@ class RoomDetail(BaseModel):
         ):
             self.recommendCapacityRange = None
 
-        # [#257] 레거시 sentinel clamp(100→50) 잔재 및 상한 초과 방어
+        # ③ [#257] 레거시 sentinel clamp(100→50) 잔재 및 상한 초과 방어 (실제 maxCapacity 기준)
         if self.recommendCapacityRange and len(self.recommendCapacityRange) == 2:
             lo, hi = self.recommendCapacityRange
             # [50,50]: MANUAL_REVIEW_FLAG(100)이 50으로 clamp된 레거시 산물
@@ -135,9 +140,6 @@ class RoomDetail(BaseModel):
             # 상한이 max_capacity 초과: max_capacity 기준으로 clamp, 하한 최솟값 1 보장
             elif self.maxCapacity > 0 and hi > self.maxCapacity:
                 self.recommendCapacityRange = [max(1, min(lo, self.maxCapacity)), self.maxCapacity]
-
-        if self.maxCapacity == self.MANUAL_REVIEW_CAPACITY_FLAG:
-            self.maxCapacity = 0
 
         # [이슈 6] recommendCapacity(단일값) fallback 로직 제거.
         # recommendCapacityRange가 None이면 그대로 None. 파서/DB 보강으로 해결.

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -1133,7 +1133,7 @@ class RoomCollectionService:
                 ),
                 "price_config": final_price_config,
                 "base_capacity": final_base_cap_int,
-                "extra_charge": final_extra_charge_int if final_extra_charge_int else None,
+                "extra_charge": final_extra_charge_int if final_extra_charge_int is not None and final_extra_charge_int > 0 else None,
                 "requires_call_on_sameday": final_requires_call,
                 "can_reserve_one_hour": final_can_reserve,
                 "image_urls": image_urls  # Save to JSONB column

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -1133,7 +1133,7 @@ class RoomCollectionService:
                 ),
                 "price_config": final_price_config,
                 "base_capacity": final_base_cap_int,
-                "extra_charge": final_extra_charge_int,
+                "extra_charge": final_extra_charge_int if final_extra_charge_int else None,
                 "requires_call_on_sameday": final_requires_call,
                 "can_reserve_one_hour": final_can_reserve,
                 "image_urls": image_urls  # Save to JSONB column

--- a/migrations/158_fix_capacity_data_quality.sql
+++ b/migrations/158_fix_capacity_data_quality.sql
@@ -3,22 +3,27 @@
 -- 처리 항목:
 --   1. recommend_capacity_range = [50,50] (6건) → max_capacity 기준 역산
 --   2. recommend_capacity_range 상한 > max_capacity (8건) → max_capacity 기준 clamp
---   3. recommend_capacity_range = [x,x] 단일값 중 sadang/dream_sadang (9건) → 수동 보정
+--   3. recommend_capacity_range = [x,x] 단일값 중 sadang/dream_sadang → 158b로 분리
 --   4. extra_charge = 0 (5건) → NULL
 --
 -- NOTE: recommend_capacity_range 컬럼 타입은 integer[] (배열)
 --       int4range 함수 및 lower()/upper() 대신 배열 인덱스([1], [2]) 사용
+--
+-- sadang/dream_sadang 단일값 보정은 별도 파일로 분리:
+--   → migrations/158b_fix_sadang_capacity.sql
 
+
+BEGIN;
 
 -- ────────────────────────────────────────────────
 -- 1. recommend_capacity_range = [50,50] 수정 (6건)
---    max_capacity 기준으로 [max*0.4, max*0.8] 수준으로 역산
---    (정수 절삭, min >= 1 보장)
+--    max_capacity 기준으로 [max-1, max] 적용 (delta=1 정책과 동일)
+--    하한 최솟값 1 보장
 -- ────────────────────────────────────────────────
 UPDATE room
 SET recommend_capacity_range = ARRAY[
-    GREATEST(1, ROUND(max_capacity * 0.4)::int),
-    GREATEST(2, ROUND(max_capacity * 0.8)::int)
+    GREATEST(1, max_capacity - 1),
+    max_capacity
 ]
 WHERE recommend_capacity_range[1] = 50
   AND recommend_capacity_range[2] = 50
@@ -29,10 +34,11 @@ WHERE recommend_capacity_range[1] = 50
 -- ────────────────────────────────────────────────
 -- 2. recommend_capacity_range 상한 > max_capacity 수정 (8건)
 --    상한을 max_capacity로 clamp, 하한은 min(기존 하한, max_capacity)
+--    하한 최솟값 1 보장 (lo=0 방지)
 -- ────────────────────────────────────────────────
 UPDATE room
 SET recommend_capacity_range = ARRAY[
-    LEAST(recommend_capacity_range[1], max_capacity),
+    GREATEST(1, LEAST(recommend_capacity_range[1], max_capacity)),
     max_capacity
 ]
 WHERE recommend_capacity_range IS NOT NULL
@@ -43,37 +49,21 @@ WHERE recommend_capacity_range IS NOT NULL
 
 
 -- ────────────────────────────────────────────────
--- 3. sadang / dream_sadang 단일값 수동 보정 (9건)
---    business_id: sadang=해당값, dream_sadang=해당값
---    실제 business_id 확인 후 적용 필요 — 아래는 조회용 SELECT
--- ────────────────────────────────────────────────
--- 현황 확인용 (실행 전 조회):
--- SELECT business_id, name, max_capacity, base_capacity, recommend_capacity_range
--- FROM room
--- WHERE recommend_capacity_range[1] = recommend_capacity_range[2]
--- ORDER BY business_id, name;
-
--- sadang / dream_sadang: base_capacity 기반 정책 → [base_capacity, max_capacity]
--- TODO: 아래 WHERE 조건의 business_id 값을 실제 값으로 교체 후 실행
--- UPDATE room
--- SET recommend_capacity_range = ARRAY[base_capacity, max_capacity]
--- WHERE business_id IN (/* sadang business_id */, /* dream_sadang business_id */)
---   AND base_capacity IS NOT NULL
---   AND recommend_capacity_range[1] = recommend_capacity_range[2];
-
-
--- ────────────────────────────────────────────────
--- 4. extra_charge = 0 → NULL (5건)
+-- 3. extra_charge = 0 → NULL (5건)
 -- ────────────────────────────────────────────────
 UPDATE room
 SET extra_charge = NULL
 WHERE extra_charge = 0;
 
 
--- 결과 검증용
+COMMIT;
+
+
+-- 결과 검증용 (COMMIT 후 별도 실행)
 -- SELECT
 --     COUNT(*) FILTER (WHERE recommend_capacity_range[1] = 50 AND recommend_capacity_range[2] = 50) AS sentinel_50_50,
 --     COUNT(*) FILTER (WHERE recommend_capacity_range IS NOT NULL AND recommend_capacity_range[2] > max_capacity) AS range_exceeds_max,
---     COUNT(*) FILTER (WHERE recommend_capacity_range[1] = recommend_capacity_range[2]) AS single_value_range,
+--     COUNT(*) FILTER (WHERE recommend_capacity_range IS NOT NULL AND recommend_capacity_range[1] < 1) AS range_lo_zero,
 --     COUNT(*) FILTER (WHERE extra_charge = 0) AS extra_charge_zero
 -- FROM room;
+-- 기대값: 모든 컬럼 0

--- a/migrations/158_fix_capacity_data_quality.sql
+++ b/migrations/158_fix_capacity_data_quality.sql
@@ -18,7 +18,7 @@
 -- 0건이면 현재 조건(max_capacity < 50) 유지 가능.
 -- 1건 이상이면 조건 범위 재검토 필요.
 -- ────────────────────────────────────────────────
--- SELECT id, name, max_capacity, recommend_capacity_range
+-- SELECT biz_item_id, name, max_capacity, recommend_capacity_range
 -- FROM room
 -- WHERE recommend_capacity_range[1] = 50
 --   AND recommend_capacity_range[2] = 50

--- a/migrations/158_fix_capacity_data_quality.sql
+++ b/migrations/158_fix_capacity_data_quality.sql
@@ -1,0 +1,79 @@
+-- Migration 158: capacity 필드 이상값 정리 (#257)
+-- 분석 기준: 2026-03-19, room 테이블 179건
+-- 처리 항목:
+--   1. recommend_capacity_range = [50,50] (6건) → max_capacity 기준 역산
+--   2. recommend_capacity_range 상한 > max_capacity (8건) → max_capacity 기준 clamp
+--   3. recommend_capacity_range = [x,x] 단일값 중 sadang/dream_sadang (9건) → 수동 보정
+--   4. extra_charge = 0 (5건) → NULL
+
+
+-- ────────────────────────────────────────────────
+-- 1. recommend_capacity_range = [50,50] 수정 (6건)
+--    max_capacity 기준으로 [max*0.4, max*0.8] 수준으로 역산
+--    (정수 절삭, min >= 1 보장)
+-- ────────────────────────────────────────────────
+UPDATE room
+SET recommend_capacity_range = int4range(
+    GREATEST(1, ROUND(max_capacity * 0.4)::int),
+    GREATEST(2, ROUND(max_capacity * 0.8)::int),
+    '[]'
+)
+WHERE lower(recommend_capacity_range) = 50
+  AND upper(recommend_capacity_range) = 50
+  AND max_capacity > 0
+  AND max_capacity < 50;
+
+
+-- ────────────────────────────────────────────────
+-- 2. recommend_capacity_range 상한 > max_capacity 수정 (8건)
+--    상한을 max_capacity로 clamp, 하한은 min(기존 하한, max_capacity)
+-- ────────────────────────────────────────────────
+UPDATE room
+SET recommend_capacity_range = int4range(
+    LEAST(lower(recommend_capacity_range), max_capacity),
+    max_capacity,
+    '[]'
+)
+WHERE recommend_capacity_range IS NOT NULL
+  AND upper(recommend_capacity_range) > max_capacity
+  AND max_capacity > 0
+  -- [50,50] 케이스는 위에서 처리했으므로 제외
+  AND NOT (lower(recommend_capacity_range) = 50 AND upper(recommend_capacity_range) = 50);
+
+
+-- ────────────────────────────────────────────────
+-- 3. sadang / dream_sadang 단일값 수동 보정 (9건)
+--    business_id: sadang=해당값, dream_sadang=해당값
+--    실제 business_id 확인 후 적용 필요 — 아래는 조회용 SELECT
+-- ────────────────────────────────────────────────
+-- 현황 확인용 (실행 전 조회):
+-- SELECT business_id, name, max_capacity, base_capacity, recommend_capacity_range
+-- FROM room
+-- WHERE lower(recommend_capacity_range) = upper(recommend_capacity_range) - 1
+--    OR lower(recommend_capacity_range) = upper(recommend_capacity_range)
+-- ORDER BY business_id, name;
+
+-- sadang / dream_sadang: base_capacity 기반 정책 → [base_capacity, max_capacity]
+-- TODO: 아래 WHERE 조건의 business_id 값을 실제 값으로 교체 후 실행
+-- UPDATE room
+-- SET recommend_capacity_range = int4range(base_capacity, max_capacity, '[]')
+-- WHERE business_id IN (/* sadang business_id */, /* dream_sadang business_id */)
+--   AND base_capacity IS NOT NULL
+--   AND lower(recommend_capacity_range) = upper(recommend_capacity_range) - 1;
+
+
+-- ────────────────────────────────────────────────
+-- 4. extra_charge = 0 → NULL (5건)
+-- ────────────────────────────────────────────────
+UPDATE room
+SET extra_charge = NULL
+WHERE extra_charge = 0;
+
+
+-- 결과 검증용
+-- SELECT
+--     COUNT(*) FILTER (WHERE lower(recommend_capacity_range) = 50 AND upper(recommend_capacity_range) = 50) AS sentinel_50_50,
+--     COUNT(*) FILTER (WHERE upper(recommend_capacity_range) > max_capacity) AS range_exceeds_max,
+--     COUNT(*) FILTER (WHERE lower(recommend_capacity_range) = upper(recommend_capacity_range) - 1) AS single_value_range,
+--     COUNT(*) FILTER (WHERE extra_charge = 0) AS extra_charge_zero
+-- FROM room;

--- a/migrations/158_fix_capacity_data_quality.sql
+++ b/migrations/158_fix_capacity_data_quality.sql
@@ -13,12 +13,25 @@
 --   → migrations/158b_fix_sadang_capacity.sql
 
 
+-- ────────────────────────────────────────────────
+-- [P1 사전 검증] UPDATE 1 실행 전 반드시 아래 SELECT를 먼저 실행하세요.
+-- 0건이면 현재 조건(max_capacity < 50) 유지 가능.
+-- 1건 이상이면 조건 범위 재검토 필요.
+-- ────────────────────────────────────────────────
+-- SELECT id, name, max_capacity, recommend_capacity_range
+-- FROM room
+-- WHERE recommend_capacity_range[1] = 50
+--   AND recommend_capacity_range[2] = 50
+--   AND max_capacity >= 50;
+
+
 BEGIN;
 
 -- ────────────────────────────────────────────────
 -- 1. recommend_capacity_range = [50,50] 수정 (6건)
 --    max_capacity 기준으로 [max-1, max] 적용 (delta=1 정책과 동일)
 --    하한 최솟값 1 보장
+--    조건: max_capacity < 50 — [50,50]이 실제 범위인 케이스(max>=50) 보호
 -- ────────────────────────────────────────────────
 UPDATE room
 SET recommend_capacity_range = ARRAY[

--- a/migrations/158_fix_capacity_data_quality.sql
+++ b/migrations/158_fix_capacity_data_quality.sql
@@ -5,6 +5,9 @@
 --   2. recommend_capacity_range 상한 > max_capacity (8건) → max_capacity 기준 clamp
 --   3. recommend_capacity_range = [x,x] 단일값 중 sadang/dream_sadang (9건) → 수동 보정
 --   4. extra_charge = 0 (5건) → NULL
+--
+-- NOTE: recommend_capacity_range 컬럼 타입은 integer[] (배열)
+--       int4range 함수 및 lower()/upper() 대신 배열 인덱스([1], [2]) 사용
 
 
 -- ────────────────────────────────────────────────
@@ -13,13 +16,12 @@
 --    (정수 절삭, min >= 1 보장)
 -- ────────────────────────────────────────────────
 UPDATE room
-SET recommend_capacity_range = int4range(
+SET recommend_capacity_range = ARRAY[
     GREATEST(1, ROUND(max_capacity * 0.4)::int),
-    GREATEST(2, ROUND(max_capacity * 0.8)::int),
-    '[]'
-)
-WHERE lower(recommend_capacity_range) = 50
-  AND upper(recommend_capacity_range) = 50
+    GREATEST(2, ROUND(max_capacity * 0.8)::int)
+]
+WHERE recommend_capacity_range[1] = 50
+  AND recommend_capacity_range[2] = 50
   AND max_capacity > 0
   AND max_capacity < 50;
 
@@ -29,16 +31,15 @@ WHERE lower(recommend_capacity_range) = 50
 --    상한을 max_capacity로 clamp, 하한은 min(기존 하한, max_capacity)
 -- ────────────────────────────────────────────────
 UPDATE room
-SET recommend_capacity_range = int4range(
-    LEAST(lower(recommend_capacity_range), max_capacity),
-    max_capacity,
-    '[]'
-)
+SET recommend_capacity_range = ARRAY[
+    LEAST(recommend_capacity_range[1], max_capacity),
+    max_capacity
+]
 WHERE recommend_capacity_range IS NOT NULL
-  AND upper(recommend_capacity_range) > max_capacity
+  AND recommend_capacity_range[2] > max_capacity
   AND max_capacity > 0
   -- [50,50] 케이스는 위에서 처리했으므로 제외
-  AND NOT (lower(recommend_capacity_range) = 50 AND upper(recommend_capacity_range) = 50);
+  AND NOT (recommend_capacity_range[1] = 50 AND recommend_capacity_range[2] = 50);
 
 
 -- ────────────────────────────────────────────────
@@ -49,17 +50,16 @@ WHERE recommend_capacity_range IS NOT NULL
 -- 현황 확인용 (실행 전 조회):
 -- SELECT business_id, name, max_capacity, base_capacity, recommend_capacity_range
 -- FROM room
--- WHERE lower(recommend_capacity_range) = upper(recommend_capacity_range) - 1
---    OR lower(recommend_capacity_range) = upper(recommend_capacity_range)
+-- WHERE recommend_capacity_range[1] = recommend_capacity_range[2]
 -- ORDER BY business_id, name;
 
 -- sadang / dream_sadang: base_capacity 기반 정책 → [base_capacity, max_capacity]
 -- TODO: 아래 WHERE 조건의 business_id 값을 실제 값으로 교체 후 실행
 -- UPDATE room
--- SET recommend_capacity_range = int4range(base_capacity, max_capacity, '[]')
+-- SET recommend_capacity_range = ARRAY[base_capacity, max_capacity]
 -- WHERE business_id IN (/* sadang business_id */, /* dream_sadang business_id */)
 --   AND base_capacity IS NOT NULL
---   AND lower(recommend_capacity_range) = upper(recommend_capacity_range) - 1;
+--   AND recommend_capacity_range[1] = recommend_capacity_range[2];
 
 
 -- ────────────────────────────────────────────────
@@ -72,8 +72,8 @@ WHERE extra_charge = 0;
 
 -- 결과 검증용
 -- SELECT
---     COUNT(*) FILTER (WHERE lower(recommend_capacity_range) = 50 AND upper(recommend_capacity_range) = 50) AS sentinel_50_50,
---     COUNT(*) FILTER (WHERE upper(recommend_capacity_range) > max_capacity) AS range_exceeds_max,
---     COUNT(*) FILTER (WHERE lower(recommend_capacity_range) = upper(recommend_capacity_range) - 1) AS single_value_range,
+--     COUNT(*) FILTER (WHERE recommend_capacity_range[1] = 50 AND recommend_capacity_range[2] = 50) AS sentinel_50_50,
+--     COUNT(*) FILTER (WHERE recommend_capacity_range IS NOT NULL AND recommend_capacity_range[2] > max_capacity) AS range_exceeds_max,
+--     COUNT(*) FILTER (WHERE recommend_capacity_range[1] = recommend_capacity_range[2]) AS single_value_range,
 --     COUNT(*) FILTER (WHERE extra_charge = 0) AS extra_charge_zero
 -- FROM room;

--- a/migrations/158b_fix_sadang_capacity.sql
+++ b/migrations/158b_fix_sadang_capacity.sql
@@ -1,0 +1,42 @@
+-- Migration 158b: sadang/dream_sadang recommend_capacity_range 단일값 보정
+-- 관련 이슈: #257 (Sub-issue of #256)
+-- 선행 조건: migrations/158_fix_capacity_data_quality.sql 실행 완료 후 적용
+--
+-- 대상: base_capacity 기반 정책 지점(sadang, dream_sadang)의 단일값 range
+--   → [base_capacity, max_capacity] 로 보정
+--
+-- 실행 전 아래 SELECT로 business_id 및 대상 룸 확인 필수
+
+
+-- ────────────────────────────────────────────────
+-- 현황 확인용 SELECT (실행 후 business_id 확인)
+-- ────────────────────────────────────────────────
+-- SELECT business_id, name, max_capacity, base_capacity, recommend_capacity_range
+-- FROM room
+-- WHERE recommend_capacity_range[1] = recommend_capacity_range[2]
+--   AND base_capacity IS NOT NULL
+-- ORDER BY business_id, name;
+
+
+-- ────────────────────────────────────────────────
+-- UPDATE (business_id 확인 후 주석 해제하여 실행)
+-- ────────────────────────────────────────────────
+-- TODO: sadang, dream_sadang의 실제 business_id를 아래에 입력 후 실행
+
+-- BEGIN;
+
+-- UPDATE room
+-- SET recommend_capacity_range = ARRAY[base_capacity, max_capacity]
+-- WHERE business_id IN (/* sadang */, /* dream_sadang */)
+--   AND base_capacity IS NOT NULL
+--   AND base_capacity < max_capacity
+--   AND recommend_capacity_range[1] = recommend_capacity_range[2];
+
+-- COMMIT;
+
+
+-- 결과 검증용
+-- SELECT business_id, name, max_capacity, base_capacity, recommend_capacity_range
+-- FROM room
+-- WHERE business_id IN (/* sadang */, /* dream_sadang */)
+-- ORDER BY business_id, name;

--- a/tests/models/test_room_detail_v2.py
+++ b/tests/models/test_room_detail_v2.py
@@ -97,3 +97,13 @@ def test_recommend_capacity_range_lower_zero_is_clamped_to_one():
     )
     assert room.recommendCapacityRange == [1, 8]
 
+
+def test_recommend_capacity_range_not_clamped_when_max_is_flag():
+    """maxCapacity=100(MANUAL_REVIEW_FLAG)일 때 range clamp가 FLAG값(100) 기준으로 동작하면 안 됨"""
+    room = RoomDetail.model_validate(
+        _room_payload(max_capacity=100, recommend_capacity_range=[3, 150])
+    )
+    assert room.maxCapacity == 0
+    # maxCapacity=0이므로 clamp 조건(> 0) 미충족 → range는 그대로 유지
+    assert room.recommendCapacityRange == [3, 150]
+

--- a/tests/models/test_room_detail_v2.py
+++ b/tests/models/test_room_detail_v2.py
@@ -71,3 +71,29 @@ def test_alias_choices_precedence():
     room = RoomDetail.model_validate(payload)
     assert room.requiresContactOnSameDay is False
 
+
+# ── #257 capacity range 이상값 방어 테스트 ─────────────────────────────────────
+
+def test_recommend_capacity_range_sentinel_50_50_returns_none():
+    """[50,50]: MANUAL_REVIEW_FLAG(100)이 50으로 clamp된 레거시 산물 → None으로 정제"""
+    room = RoomDetail.model_validate(
+        _room_payload(max_capacity=8, recommend_capacity_range=[50, 50])
+    )
+    assert room.recommendCapacityRange is None
+
+
+def test_recommend_capacity_range_upper_exceeds_max_is_clamped():
+    """range 상한이 max_capacity 초과 → max_capacity 기준으로 clamp"""
+    room = RoomDetail.model_validate(
+        _room_payload(max_capacity=8, recommend_capacity_range=[4, 12])
+    )
+    assert room.recommendCapacityRange == [4, 8]
+
+
+def test_recommend_capacity_range_lower_zero_is_clamped_to_one():
+    """range 하한이 0 → clamp 후 하한 최솟값 1 보장"""
+    room = RoomDetail.model_validate(
+        _room_payload(max_capacity=8, recommend_capacity_range=[0, 12])
+    )
+    assert room.recommendCapacityRange == [1, 8]
+


### PR DESCRIPTION

#  개요
  DB에 고착된 recommend_capacity_range 이상값(총 36건)과 extra_charge = 0(5건)을 처리합니다. 코드 2곳과 마이그레이션 스크립트 1개로 구성됩니다.

 # 변경 사항
 ## 1. dto.py — populate_v2_fields() 방어 로직 추가

  기존에는 [100, 100]만 None으로 변환했으나, 레거시 sentinel 잔재([50, 50])와 range 상한 초과 케이스가 프론트엔드에 그대로 노출되는 문제가 있었습니다.

 ```
 # [#257] 레거시 sentinel clamp(100→50) 잔재 및 상한 초과 방어
  if self.recommendCapacityRange and len(self.recommendCapacityRange) == 2:
      lo, hi = self.recommendCapacityRange
      if lo == 50 and hi == 50:                          # sentinel 잔재 → None
          self.recommendCapacityRange = None
      elif self.maxCapacity > 0 and hi > self.maxCapacity:  # 상한 초과 → clamp
          self.recommendCapacityRange = [min(lo, self.maxCapacity), self.maxCapacity]
```
##  2. room_collection_service.py — extra_charge = 0 → None
  파서가 "0원" 패턴을 추출하거나 _coerce_int(0)이 반환하는 0이 그대로 저장되는 경로를 차단합니다.

```
  - "extra_charge": final_extra_charge_int,
  + "extra_charge": final_extra_charge_int if final_extra_charge_int else None,
```

##  3. migrations/158_fix_capacity_data_quality.sql — DB 직접 수정

  ┌────────────────────────────────────┬──────┬─────────────────────────────────────────────────────────────────────┐
  │             처리 항목              │ 대상 │                                방법                                 │
  ├────────────────────────────────────┼──────┼─────────────────────────────────────────────────────────────────────┤
  │ recommend_capacity_range = [50,50] │ 6건  │ max_capacity × 0.4~0.8 역산                                         │
  ├────────────────────────────────────┼──────┼─────────────────────────────────────────────────────────────────────┤
  │ range 상한 > max_capacity          │ 8건  │ max_capacity 기준 clamp                                             │
  ├────────────────────────────────────┼──────┼─────────────────────────────────────────────────────────────────────┤
  │ sadang/dream_sadang 단일값         │ 9건  │ [base_capacity, max_capacity] (TODO 주석, business_id 확인 후 실행) │
  ├────────────────────────────────────┼──────┼─────────────────────────────────────────────────────────────────────┤
  │ extra_charge = 0                   │ 5건  │ NULL 변환                                                           │
  └────────────────────────────────────┴──────┴─────────────────────────────────────────────────────────────────────┘

  결과 검증용 SELECT 쿼리 포함.

#  주의 사항

  - 마이그레이션 스크립트의 **항목 3(sadang/dream_sadang)**은 TODO 상태입니다. 실제 business_id 확인 후 주석 해제하여 별도 실행 필요합니다.
  - 코드 변경(1, 2)은 DB 수정(3)과 무관하게 먼저 배포 가능합니다. 방어 로직은 안전 방향(값 축소/제거)이므로 순서 무관합니다.

 # 체크리스트

  - 마이그레이션 실행 전 검증용 SELECT로 대상 건수 확인
  - sadang/dream_sadang business_id 확인 후 항목 3 실행
  - 마이그레이션 실행 후 검증 SELECT로 처리 결과 0건 확인
  - extra_charge = 0으로 저장되던 룸에서 이제 null 반환 확인

  Closes #257 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed legacy sentinel capacity values so invalid recommended capacities no longer appear.
  * Prevented recommended capacity ranges from exceeding a room’s maximum capacity.
  * Treated zero/absent extra charges as no charge (stored as null) so billing displays correctly.

* **Chores**
  * Applied a one-time data correction to existing room records to align recommendations and extra-charge values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->