### PR TITLE
refactor: recommend_capacity_range delta 계산 단순화

### DIFF
--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -39,7 +39,7 @@ class RoomCollectionService:
     # - 15,000~19,999 KRW -> 7~8 people
     # - 20,000+ KRW -> 10+ people
     # max_capacity 규칙: recommend_range 상한 + 3 이상
-    # recommend < 9 → ±1, recommend >= 9 → ±2
+    # recommend_capacity_range: 모든 rec_cap에 대해 ±1 고정 (delta=1, #258)
     PRICE_BAND_CAPACITY_DEFAULTS: List[Dict[str, Any]] = [
         {
             "name": "5k_10k",
@@ -1210,7 +1210,7 @@ class RoomCollectionService:
                 and len(default_range) == 2
                 and all(isinstance(v, int) for v in default_range)
             ):
-                delta = 2 if default_rec >= 9 else 1
+                delta = 1  # ±1 고정 (rec_cap >= 9 → ±2 분기 제거, #258)
                 default_range = [max(default_rec - delta, 1), min(default_rec + delta, default_max)]
 
             rec_cap = default_rec

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -1976,8 +1976,8 @@ class RoomCollectionService:
             return [base_cap, real_max]
             
         # 3. 추가 요금 없는 경우 (기본)
-        # recommend < 9 → ±1, recommend >= 9 → ±2
-        delta = 2 if rec_cap >= 9 else 1
+        # ±1 고정: rec_cap >= 9 시 ±2 분기는 max_cap에 걸려 단일값([x,x])이 되는 역효과가 있어 제거 (#258)
+        delta = 1
         min_c = max(rec_cap - delta, 1)
         max_c = min(rec_cap + delta, max_cap) if max_cap > 0 else rec_cap + delta
 

--- a/tests/services/test_room_collection_service.py
+++ b/tests/services/test_room_collection_service.py
@@ -361,13 +361,13 @@ class TestV2NewFields:
         assert room_data["recommend_capacity_range"] == [4, 6]
         assert room_data["price_config"] == []
     
-    # ============== TC: range 없으면 ±1/±2 Fallback ==============
+    # ============== TC: range 없으면 ±1 Fallback ==============
     @pytest.mark.asyncio
     async def test_fallback_range_from_single_capacity(self, service, mock_supabase):
         """파서가 범위를 반환하지 않으면 규칙 기반으로 계산
 
         Rationale:
-            recommend < 9 → ±1, recommend >= 9 → ±2
+            모든 rec_cap에 대해 ±1 고정 (delta=1, #258)
             rec=4, price=10000 → price band(10k_15k) 적용 → rec=4, ±1 → [3, 5]
         """
         business = {"businessId": "biz1", "businessDisplayName": "테스트", "coordinates": None}


### PR DESCRIPTION
closes #258 
# 개요
  _calculate_capacity_range()에서 rec_cap >= 9일 때 delta를 2로 키우는 분기를 제거하고 전 가격대에서 delta = 1로 통일합니다.

 # 변경 배경
  기존 delta = 2 if rec_cap >= 9 else 1 정책은 고인원 룸의 권장 범위를 넓히려는 의도였으나, max_cap에 걸려 오히려 단일값 [x, x]가 되는 역효과가 발생했습니다.

  예시 (rec_cap=10, max_cap=10):
  - AS-IS: min=8, max=min(12,10)=10 → [8, 10] (비대칭)
  - TO-BE: min=9, max=min(11,10)=10 → [9, 10] (대칭)

# 변경 사항
```
  - # recommend < 9 → ±1, recommend >= 9 → ±2
  - delta = 2 if rec_cap >= 9 else 1
  + # ±1 고정: rec_cap >= 9 시 ±2 분기는 max_cap에 걸려 단일값([x,x])이 되는 역효과가 있어 제거 (#258)
  + delta = 1
```

#  영향 범위
  - base_capacity 기반 지점(sadang, dream_sadang)은 해당 경로([base_cap, max_cap])를 타므로 영향 없음
  - 재크롤 전까지 기존 DB 값은 변경되지 않음. 재크롤 시 rec_cap >= 9인 룸의 range가 ±2에서 ±1로 좁아짐

#  체크리스트
  - _calculate_capacity_range() 단위 테스트에서 rec_cap >= 9 케이스 결과 확인
  - base_capacity 있는 룸에 영향 없음 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted room capacity range calculations to provide more consistent results when determining availability with no extra charges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->