### PR TITLE
feat: 요일별 variant room 병합 처리 추가

### DIFF
--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -1918,10 +1918,15 @@ class RoomCollectionService:
         cleaned = re.sub(r"\s*(예약|방문\s*상담|문의|안내)$", "", cleaned).strip()
         return cleaned if cleaned else name
 
-    # 시간대/요일 suffix 패턴 (clean_name 뒤에 붙는 형태)
+    # 시간대/요일 suffix 패턴 (clean_name 뒤에 붙는 형태) — base_name 추출 시 제거 대상
     _DAY_VARIANT_SUFFIX_RE = re.compile(
         r"\s*\((?:평일\s*낮|평일\s*오전|평일\s*야간|주말/공휴일|평일|주말|공휴일|심야|야간|주간)\)\s*$"
     )
+    # 평일/주말 분류용 패턴 (P2-2: 매 호출 시 컴파일 방지)
+    _WEEKDAY_NAME_RE = re.compile(r"\((?:평일|평일\s*낮|평일\s*오전|평일\s*야간)\)$")
+    _WEEKEND_NAME_RE = re.compile(r"\((?:주말|주말/공휴일|공휴일)\)$")
+    # 시간대 전용 suffix (평일/주말 없이 시간대만 명시) — 요일 병합 대상에서 제외
+    _TIME_ONLY_NAME_RE = re.compile(r"\((?:심야|야간|주간)\)$")
 
     @classmethod
     def _get_base_room_name(cls, clean_name: str) -> str:
@@ -1935,6 +1940,8 @@ class RoomCollectionService:
     def _classify_day_variant(cls, clean_name: str, day_type: Optional[str]) -> Optional[str]:
         """clean_name suffix 또는 day_type으로 요일 분류를 반환한다.
 
+        심야/야간/주간처럼 요일 정보 없는 시간대 전용 suffix는 None 반환 → 병합 대상 제외.
+
         Returns:
             "weekday" | "weekend" | None
         """
@@ -1942,9 +1949,13 @@ class RoomCollectionService:
             return "weekend"
         if day_type == "weekday":
             return "weekday"
-        if re.search(r"\((?:평일|평일\s*낮|평일\s*오전|평일\s*야간)\)$", clean_name or ""):
+        name = clean_name or ""
+        # 시간대 전용 suffix는 요일 분류 불가 → 명시적 제외
+        if cls._TIME_ONLY_NAME_RE.search(name):
+            return None
+        if cls._WEEKDAY_NAME_RE.search(name):
             return "weekday"
-        if re.search(r"\((?:주말|주말/공휴일|공휴일)\)$", clean_name or ""):
+        if cls._WEEKEND_NAME_RE.search(name):
             return "weekend"
         return None
 
@@ -2006,21 +2017,29 @@ class RoomCollectionService:
                 primary_parsed = dict(parsed_results.get(wd_id, {}))
                 secondary_parsed = parsed_results.get(we_id, {})
 
-                # capacity: 더 높은 값 사용
+                # capacity: 더 높은 값 사용 (None 덮어쓰기 방어)
                 wd_max = primary_parsed.get("max_capacity")
                 we_max = secondary_parsed.get("max_capacity")
                 if isinstance(we_max, int) and isinstance(wd_max, int) and we_max > wd_max:
                     primary_parsed["max_capacity"] = we_max
-                    primary_parsed["recommend_capacity"] = secondary_parsed.get("recommend_capacity")
-                    primary_parsed["recommend_capacity_range"] = secondary_parsed.get("recommend_capacity_range")
+                    we_rec = secondary_parsed.get("recommend_capacity")
+                    if we_rec is not None:
+                        primary_parsed["recommend_capacity"] = we_rec
+                        primary_parsed["recommend_capacity_range"] = secondary_parsed.get("recommend_capacity_range")
 
                 # price_config: 주말 가격이 다를 때 weekend override 추가
+                # 기존 surcharges 보존 후 overrides에 weekend 항목만 추가
                 wd_price = self._extract_price(wd_room)
                 we_price = self._extract_price(we_room)
                 if wd_price and we_price and wd_price != we_price:
+                    existing_cfg = primary_parsed.get("price_config") or {}
+                    existing_surcharges = existing_cfg.get("surcharges", []) if isinstance(existing_cfg, dict) else []
+                    existing_overrides = existing_cfg.get("overrides", []) if isinstance(existing_cfg, dict) else []
+                    # 기존 overrides 중 weekend 항목은 교체, 나머지는 보존
+                    non_weekend = [o for o in existing_overrides if o.get("day_type") != "weekend"]
                     primary_parsed["price_config"] = {
                         "default": wd_price,
-                        "overrides": [
+                        "overrides": non_weekend + [
                             {
                                 "day_type": "weekend",
                                 "start_hour": "00:00",
@@ -2028,7 +2047,7 @@ class RoomCollectionService:
                                 "price": we_price,
                             }
                         ],
-                        "surcharges": [],
+                        "surcharges": existing_surcharges,
                     }
 
                 primary_parsed["clean_name"] = base_name
@@ -2042,6 +2061,11 @@ class RoomCollectionService:
                 )
             else:
                 # 병합 불가: 모두 원형 유지
+                logger.info(
+                    "[variant_merge] 병합 조건 미충족 스킵: base=%s weekday=%d weekend=%d other=%d"
+                    " — DB 마이그레이션 대상 아님",
+                    base_name, len(weekday_rooms), len(weekend_rooms), len(other_rooms),
+                )
                 for r in group:
                     merged_rooms.append(r)
                     merged_parsed[r["bizItemId"]] = parsed_results.get(r["bizItemId"], {})

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -537,6 +537,9 @@ class RoomCollectionService:
         # 병렬 처리를 위한 청크 분할
         parsed_results = await self._parse_with_concurrency(parse_items)
 
+        # 2.5 요일 variant 병합: 동일 지점 내 평일/주말 분리 룸을 단일 룸으로 통합 (#259)
+        target_rooms, parsed_results = self._merge_day_variant_rooms(target_rooms, parsed_results)
+
         # 3. DB 저장 (Branch -> Room(이미지 포함))
         saved = await self._save_to_db(business, target_rooms, parsed_results, source_hint=source_hint)
         if not saved:
@@ -1914,6 +1917,136 @@ class RoomCollectionService:
         cleaned = re.sub(r"\[.*?\]", "", name).strip()
         cleaned = re.sub(r"\s*(예약|방문\s*상담|문의|안내)$", "", cleaned).strip()
         return cleaned if cleaned else name
+
+    # 시간대/요일 suffix 패턴 (clean_name 뒤에 붙는 형태)
+    _DAY_VARIANT_SUFFIX_RE = re.compile(
+        r"\s*\((?:평일\s*낮|평일\s*오전|평일\s*야간|주말/공휴일|평일|주말|공휴일|심야|야간|주간)\)\s*$"
+    )
+
+    @classmethod
+    def _get_base_room_name(cls, clean_name: str) -> str:
+        """clean_name에서 시간대/요일 suffix를 제거한 기본 룸 이름을 반환한다.
+
+        예: "1번룸 (평일 낮)" → "1번룸", "1번룸 (주말)" → "1번룸"
+        """
+        return cls._DAY_VARIANT_SUFFIX_RE.sub("", (clean_name or "")).strip()
+
+    @classmethod
+    def _classify_day_variant(cls, clean_name: str, day_type: Optional[str]) -> Optional[str]:
+        """clean_name suffix 또는 day_type으로 요일 분류를 반환한다.
+
+        Returns:
+            "weekday" | "weekend" | None
+        """
+        if day_type == "weekend":
+            return "weekend"
+        if day_type == "weekday":
+            return "weekday"
+        if re.search(r"\((?:평일|평일\s*낮|평일\s*오전|평일\s*야간)\)$", clean_name or ""):
+            return "weekday"
+        if re.search(r"\((?:주말|주말/공휴일|공휴일)\)$", clean_name or ""):
+            return "weekend"
+        return None
+
+    def _merge_day_variant_rooms(
+        self,
+        rooms: List[Dict],
+        parsed_results: Dict[str, Dict],
+    ) -> Tuple[List[Dict], Dict[str, Dict]]:
+        """평일/주말 요일 variant room을 병합한다. (#259)
+
+        같은 지점 내 동일 base_name을 공유하는 평일/주말 분리 룸을 단일 룸으로 합친다.
+        - capacity: 평일/주말 중 높은 값 사용
+        - price_config: 주말 가격이 다르면 weekend override 추가
+        - 병합된 주말 룸의 biz_item_id는 더 이상 크롤 대상이 되지 않으므로
+          DB에 잔존하는 해당 행은 별도 마이그레이션으로 정리 필요
+
+        병합 조건: 동일 base_name 그룹 내 weekday 1개 + weekend 1개 (기타 없음)
+        조건 미충족 시 모든 룸을 원형 그대로 유지한다.
+        """
+        groups: Dict[str, List[Dict]] = {}
+        for room in rooms:
+            rid = room["bizItemId"]
+            parsed = parsed_results.get(rid, {})
+            clean = parsed.get("clean_name") or room.get("name", "")
+            base = self._get_base_room_name(clean)
+            groups.setdefault(base, []).append(room)
+
+        merged_rooms: List[Dict] = []
+        merged_parsed: Dict[str, Dict] = {}
+
+        for base_name, group in groups.items():
+            if len(group) == 1:
+                r = group[0]
+                merged_rooms.append(r)
+                merged_parsed[r["bizItemId"]] = parsed_results.get(r["bizItemId"], {})
+                continue
+
+            weekday_rooms = []
+            weekend_rooms = []
+            other_rooms = []
+            for r in group:
+                rid = r["bizItemId"]
+                p = parsed_results.get(rid, {})
+                variant = self._classify_day_variant(
+                    p.get("clean_name") or r.get("name", ""),
+                    p.get("day_type"),
+                )
+                if variant == "weekday":
+                    weekday_rooms.append(r)
+                elif variant == "weekend":
+                    weekend_rooms.append(r)
+                else:
+                    other_rooms.append(r)
+
+            # 병합 가능 조건: weekday 1개 + weekend 1개, 나머지 없음
+            if len(weekday_rooms) == 1 and len(weekend_rooms) == 1 and not other_rooms:
+                wd_room, we_room = weekday_rooms[0], weekend_rooms[0]
+                wd_id, we_id = wd_room["bizItemId"], we_room["bizItemId"]
+                primary_parsed = dict(parsed_results.get(wd_id, {}))
+                secondary_parsed = parsed_results.get(we_id, {})
+
+                # capacity: 더 높은 값 사용
+                wd_max = primary_parsed.get("max_capacity")
+                we_max = secondary_parsed.get("max_capacity")
+                if isinstance(we_max, int) and isinstance(wd_max, int) and we_max > wd_max:
+                    primary_parsed["max_capacity"] = we_max
+                    primary_parsed["recommend_capacity"] = secondary_parsed.get("recommend_capacity")
+                    primary_parsed["recommend_capacity_range"] = secondary_parsed.get("recommend_capacity_range")
+
+                # price_config: 주말 가격이 다를 때 weekend override 추가
+                wd_price = self._extract_price(wd_room)
+                we_price = self._extract_price(we_room)
+                if wd_price and we_price and wd_price != we_price:
+                    primary_parsed["price_config"] = {
+                        "default": wd_price,
+                        "overrides": [
+                            {
+                                "day_type": "weekend",
+                                "start_hour": "00:00",
+                                "end_hour": "24:00",
+                                "price": we_price,
+                            }
+                        ],
+                        "surcharges": [],
+                    }
+
+                primary_parsed["clean_name"] = base_name
+                primary_parsed["day_type"] = None
+
+                merged_rooms.append(wd_room)
+                merged_parsed[wd_id] = primary_parsed
+                logger.info(
+                    "[variant_merge] 요일 variant 병합: base=%s wd_id=%s we_id=%s",
+                    base_name, wd_id, we_id,
+                )
+            else:
+                # 병합 불가: 모두 원형 유지
+                for r in group:
+                    merged_rooms.append(r)
+                    merged_parsed[r["bizItemId"]] = parsed_results.get(r["bizItemId"], {})
+
+        return merged_rooms, merged_parsed
 
     def _calculate_capacity_range(
         self,

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -2025,7 +2025,9 @@ class RoomCollectionService:
                     we_rec = secondary_parsed.get("recommend_capacity")
                     if we_rec is not None:
                         primary_parsed["recommend_capacity"] = we_rec
-                        primary_parsed["recommend_capacity_range"] = secondary_parsed.get("recommend_capacity_range")
+                    we_range = secondary_parsed.get("recommend_capacity_range")
+                    if we_range is not None:
+                        primary_parsed["recommend_capacity_range"] = we_range
 
                 # price_config: 주말 가격이 다를 때 weekend override 추가
                 # 기존 surcharges 보존 후 overrides에 weekend 항목만 추가
@@ -2039,20 +2041,20 @@ class RoomCollectionService:
                     non_weekend = [o for o in existing_overrides if o.get("day_type") != "weekend"]
                     primary_parsed["price_config"] = {
                         "default": wd_price,
-                        "overrides": non_weekend + [
-                            {
-                                "day_type": "weekend",
-                                "start_hour": "00:00",
-                                "end_hour": "24:00",
-                                "price": we_price,
-                            }
-                        ],
+                        "overrides": [*non_weekend, {
+                            "day_type": "weekend",
+                            "start_hour": "00:00",
+                            "end_hour": "24:00",
+                            "price": we_price,
+                        }],
                         "surcharges": existing_surcharges,
                     }
 
                 primary_parsed["clean_name"] = base_name
                 primary_parsed["day_type"] = None
 
+                # we_id(주말 룸)는 병합 후 의도적으로 드롭됨 — DB 마이그레이션 시 별도 정리 필요
+                # TODO: 추후 DB cleanup 스크립트에서 we_id 행 삭제 처리
                 merged_rooms.append(wd_room)
                 merged_parsed[wd_id] = primary_parsed
                 logger.info(
@@ -2062,8 +2064,8 @@ class RoomCollectionService:
             else:
                 # 병합 불가: 모두 원형 유지
                 logger.info(
-                    "[variant_merge] 병합 조건 미충족 스킵: base=%s weekday=%d weekend=%d other=%d"
-                    " — DB 마이그레이션 대상 아님",
+                    "[variant_merge] 병합 조건 미충족으로 스킵: base=%s weekday=%d weekend=%d other=%d"
+                    " — DB 마이그레이션 해당 아님",
                     base_name, len(weekday_rooms), len(weekend_rooms), len(other_rooms),
                 )
                 for r in group:

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -538,10 +538,16 @@ class RoomCollectionService:
         parsed_results = await self._parse_with_concurrency(parse_items)
 
         # 2.5 요일 variant 병합: 동일 지점 내 평일/주말 분리 룸을 단일 룸으로 통합 (#259)
-        target_rooms, parsed_results = self._merge_day_variant_rooms(target_rooms, parsed_results)
+        target_rooms, parsed_results, variant_orphan_ids = self._merge_day_variant_rooms(
+            target_rooms, parsed_results
+        )
 
         # 3. DB 저장 (Branch -> Room(이미지 포함))
         saved = await self._save_to_db(business, target_rooms, parsed_results, source_hint=source_hint)
+
+        # 3.5 병합으로 드롭된 주말 룸 고아 행 삭제 (저장 성공 시에만)
+        if saved and variant_orphan_ids:
+            self._delete_variant_orphans(variant_orphan_ids)
         if not saved:
             logger.warning(
                 "Skipped DB save for requested business_id=%s due to missing business_id in fetched payload",
@@ -1923,7 +1929,7 @@ class RoomCollectionService:
         r"\s*\((?:평일\s*낮|평일\s*오전|평일\s*야간|주말/공휴일|평일|주말|공휴일|심야|야간|주간)\)\s*$"
     )
     # 평일/주말 분류용 패턴 (P2-2: 매 호출 시 컴파일 방지)
-    _WEEKDAY_NAME_RE = re.compile(r"\((?:평일|평일\s*낮|평일\s*오전|평일\s*야간)\)$")
+    _WEEKDAY_NAME_RE = re.compile(r"\((?:평일\s*낮|평일\s*오전|평일\s*야간|평일)\)$")
     _WEEKEND_NAME_RE = re.compile(r"\((?:주말|주말/공휴일|공휴일)\)$")
     # 시간대 전용 suffix (평일/주말 없이 시간대만 명시) — 요일 병합 대상에서 제외
     _TIME_ONLY_NAME_RE = re.compile(r"\((?:심야|야간|주간)\)$")
@@ -1963,17 +1969,21 @@ class RoomCollectionService:
         self,
         rooms: List[Dict],
         parsed_results: Dict[str, Dict],
-    ) -> Tuple[List[Dict], Dict[str, Dict]]:
+    ) -> Tuple[List[Dict], Dict[str, Dict], List[str]]:
         """평일/주말 요일 variant room을 병합한다. (#259)
 
         같은 지점 내 동일 base_name을 공유하는 평일/주말 분리 룸을 단일 룸으로 합친다.
         - capacity: 평일/주말 중 높은 값 사용
-        - price_config: 주말 가격이 다르면 weekend override 추가
-        - 병합된 주말 룸의 biz_item_id는 더 이상 크롤 대상이 되지 않으므로
-          DB에 잔존하는 해당 행은 별도 마이그레이션으로 정리 필요
+        - price_config: 주말 가격이 다르면 weekend override dict 형식으로 추가
+          (dict 형식: {default, overrides, surcharges} — availability_service._resolve_slot_price 소비)
+        - 병합된 주말 룸(we_id)은 반환값 dropped_ids에 포함 → 호출자가 DB에서 삭제
 
         병합 조건: 동일 base_name 그룹 내 weekday 1개 + weekend 1개 (기타 없음)
         조건 미충족 시 모든 룸을 원형 그대로 유지한다.
+
+        Returns:
+            (merged_rooms, merged_parsed, dropped_ids)
+            dropped_ids: 병합으로 드롭된 주말 룸의 biz_item_id 목록 (DB cleanup 대상)
         """
         groups: Dict[str, List[Dict]] = {}
         for room in rooms:
@@ -1985,6 +1995,7 @@ class RoomCollectionService:
 
         merged_rooms: List[Dict] = []
         merged_parsed: Dict[str, Dict] = {}
+        dropped_ids: List[str] = []
 
         for base_name, group in groups.items():
             if len(group) == 1:
@@ -2053,8 +2064,8 @@ class RoomCollectionService:
                 primary_parsed["clean_name"] = base_name
                 primary_parsed["day_type"] = None
 
-                # we_id(주말 룸)는 병합 후 의도적으로 드롭됨 — DB 마이그레이션 시 별도 정리 필요
-                # TODO: 추후 DB cleanup 스크립트에서 we_id 행 삭제 처리
+                # we_id(주말 룸)는 병합 후 의도적으로 드롭됨 → dropped_ids에 수집하여 호출자가 DB 삭제
+                dropped_ids.append(we_id)
                 merged_rooms.append(wd_room)
                 merged_parsed[wd_id] = primary_parsed
                 logger.info(
@@ -2072,7 +2083,26 @@ class RoomCollectionService:
                     merged_rooms.append(r)
                     merged_parsed[r["bizItemId"]] = parsed_results.get(r["bizItemId"], {})
 
-        return merged_rooms, merged_parsed
+        return merged_rooms, merged_parsed, dropped_ids
+
+    def _delete_variant_orphans(self, orphan_ids: List[str]) -> None:
+        """병합으로 드롭된 주말 variant 룸 행을 DB에서 삭제한다. (#259)
+
+        _merge_day_variant_rooms에서 반환된 dropped_ids를 받아 처리한다.
+        삭제 실패는 warning 로그만 남기고 전체 크롤 플로우를 중단하지 않는다.
+        """
+        if not orphan_ids:
+            return
+        try:
+            self.supabase.table("room").delete().in_("biz_item_id", orphan_ids).execute()
+            logger.info(
+                "[variant_merge] 고아 variant 룸 %d건 DB 삭제: %s",
+                len(orphan_ids), orphan_ids,
+            )
+        except Exception as e:  # noqa: BLE001
+            logger.warning(
+                "[variant_merge] 고아 variant 룸 DB 삭제 실패 (크롤 중단 없음): %s", e,
+            )
 
     def _calculate_capacity_range(
         self,

--- a/migrations/159_cleanup_variant_orphan_rooms.sql
+++ b/migrations/159_cleanup_variant_orphan_rooms.sql
@@ -5,6 +5,10 @@
 --   파이프라인에서 드롭되어 DB 업데이트를 받지 못하고 고아 행으로 잔존함.
 --   이 마이그레이션은 "평일/주말 쌍으로 존재하는 룸 중 주말 룸"을 정리한다.
 --
+-- 병합 조건: Python _merge_day_variant_rooms와 동일
+--   동일 business_id + base_name 그룹 내 weekday 1개 + weekend 1개, 나머지 0개
+--   → 조건 불충족 그룹(variant 3개 이상 등)은 삭제하지 않음
+--
 -- 실행 시점:
 --   1. _merge_day_variant_rooms 코드 배포 완료 후
 --   2. 대상 business_id에 대해 재크롤링 완료 후
@@ -21,47 +25,105 @@
 
 -- ────────────────────────────────────────────────
 -- Step 0: 삭제 대상 사전 확인 (실행 후 결과 검토 필수)
--- 동일 business_id 내에서 base_name이 동일한 weekday/weekend 쌍을 찾아 weekend를 대상으로 조회
+-- 병합 조건(wd=1, we=1, other=0)을 충족하는 그룹의 weekend 룸만 조회
 -- ────────────────────────────────────────────────
+WITH base_names AS (
+    -- 각 룸의 base_name과 day_class 계산 (Python _classify_day_variant 대응)
+    SELECT
+        biz_item_id,
+        business_id,
+        name,
+        regexp_replace(
+            name,
+            '\s*\((?:평일\s*낮|평일\s*오전|평일\s*야간|주말/공휴일|주말|공휴일|평일|심야|야간|주간)\)\s*$',
+            ''
+        ) AS base_name,
+        CASE
+            WHEN name ~ '\((?:평일\s*낮|평일\s*오전|평일\s*야간|평일)\)$' THEN 'weekday'
+            WHEN name ~ '\((?:주말/공휴일|주말|공휴일)\)$'                THEN 'weekend'
+            ELSE 'other'
+        END AS day_class
+    FROM room
+),
+counts AS (
+    -- base_name별 weekday/weekend/other 개수 집계
+    SELECT
+        business_id,
+        base_name,
+        COUNT(*) FILTER (WHERE day_class = 'weekday') AS wd_cnt,
+        COUNT(*) FILTER (WHERE day_class = 'weekend') AS we_cnt,
+        COUNT(*) FILTER (WHERE day_class = 'other')   AS other_cnt
+    FROM base_names
+    GROUP BY business_id, base_name
+)
 SELECT
-    we.biz_item_id   AS orphan_biz_item_id,
-    we.name          AS orphan_name,
-    wd.biz_item_id   AS primary_biz_item_id,
-    wd.name          AS primary_name,
-    we.business_id
-FROM room we
-JOIN room wd
-  ON wd.business_id = we.business_id
- AND regexp_replace(wd.name, '\s*\((?:평일\s*낮|평일\s*오전|평일\s*야간|평일)\)\s*$', '')
-   = regexp_replace(we.name, '\s*\((?:주말[^)]*|공휴일)\)\s*$', '')
- AND wd.biz_item_id <> we.biz_item_id
-WHERE we.name ~ '\((?:주말|주말/공휴일|공휴일)'
-  AND wd.name ~ '\((?:평일'
-ORDER BY we.business_id, we.name;
+    bn.biz_item_id AS orphan_biz_item_id,
+    bn.name        AS orphan_name,
+    bn.business_id,
+    c.wd_cnt,
+    c.we_cnt
+FROM base_names bn
+JOIN counts c
+  ON c.business_id = bn.business_id
+ AND c.base_name   = bn.base_name
+WHERE bn.day_class = 'weekend'
+  AND c.wd_cnt     = 1
+  AND c.we_cnt     = 1
+  AND c.other_cnt  = 0
+ORDER BY bn.business_id, bn.name;
 
 
 -- ────────────────────────────────────────────────
 -- Step 1: 고아 주말 variant 룸 삭제
 -- Step 0 결과를 확인한 뒤 실행하세요.
+-- RETURNING으로 실제 삭제 건수를 보고합니다.
 -- ────────────────────────────────────────────────
 BEGIN;
 
-DELETE FROM room
-WHERE biz_item_id IN (
-    SELECT we.biz_item_id
-    FROM room we
-    JOIN room wd
-      ON wd.business_id = we.business_id
-     AND regexp_replace(wd.name, '\s*\((?:평일\s*낮|평일\s*오전|평일\s*야간|평일)\)\s*$', '')
-       = regexp_replace(we.name, '\s*\((?:주말[^)]*|공휴일)\)\s*$', '')
-     AND wd.biz_item_id <> we.biz_item_id
-    WHERE we.name ~ '\((?:주말|주말/공휴일|공휴일)'
-      AND wd.name ~ '\((?:평일'
-);
-
--- 삭제 건수 확인
-SELECT 'deleted orphan variant rooms' AS action, COUNT(*) AS remaining_weekend_variants
-FROM room
-WHERE name ~ '\((?:주말|주말/공휴일|공휴일)';
+WITH base_names AS (
+    SELECT
+        biz_item_id,
+        business_id,
+        regexp_replace(
+            name,
+            '\s*\((?:평일\s*낮|평일\s*오전|평일\s*야간|주말/공휴일|주말|공휴일|평일|심야|야간|주간)\)\s*$',
+            ''
+        ) AS base_name,
+        CASE
+            WHEN name ~ '\((?:평일\s*낮|평일\s*오전|평일\s*야간|평일)\)$' THEN 'weekday'
+            WHEN name ~ '\((?:주말/공휴일|주말|공휴일)\)$'                THEN 'weekend'
+            ELSE 'other'
+        END AS day_class
+    FROM room
+),
+counts AS (
+    SELECT
+        business_id,
+        base_name,
+        COUNT(*) FILTER (WHERE day_class = 'weekday') AS wd_cnt,
+        COUNT(*) FILTER (WHERE day_class = 'weekend') AS we_cnt,
+        COUNT(*) FILTER (WHERE day_class = 'other')   AS other_cnt
+    FROM base_names
+    GROUP BY business_id, base_name
+),
+orphans AS (
+    -- 병합 조건 충족(wd=1, we=1, other=0)인 그룹의 weekend 룸만 삭제 대상
+    SELECT bn.biz_item_id
+    FROM base_names bn
+    JOIN counts c
+      ON c.business_id = bn.business_id
+     AND c.base_name   = bn.base_name
+    WHERE bn.day_class  = 'weekend'
+      AND c.wd_cnt      = 1
+      AND c.we_cnt      = 1
+      AND c.other_cnt   = 0
+),
+deleted AS (
+    DELETE FROM room
+    WHERE biz_item_id IN (SELECT biz_item_id FROM orphans)
+    RETURNING biz_item_id
+)
+SELECT 'deleted orphan variant rooms' AS action, COUNT(*) AS deleted_count
+FROM deleted;
 
 COMMIT;

--- a/migrations/159_cleanup_variant_orphan_rooms.sql
+++ b/migrations/159_cleanup_variant_orphan_rooms.sql
@@ -1,0 +1,67 @@
+-- Migration 159: 요일 variant 병합 후 고아 행(orphan row) 정리 (#259)
+--
+-- 배경:
+--   _merge_day_variant_rooms 로직이 배포된 후 재크롤링 시 주말 variant 룸(we_id)은
+--   파이프라인에서 드롭되어 DB 업데이트를 받지 못하고 고아 행으로 잔존함.
+--   이 마이그레이션은 "평일/주말 쌍으로 존재하는 룸 중 주말 룸"을 정리한다.
+--
+-- 실행 시점:
+--   1. _merge_day_variant_rooms 코드 배포 완료 후
+--   2. 대상 business_id에 대해 재크롤링 완료 후
+--      (재크롤링 시 _delete_variant_orphans가 자동으로 삭제하므로 이 스크립트는 보조 수단)
+--   3. 재크롤링 전 수동 정리가 필요한 경우 이 스크립트를 사용
+--
+-- NOTE: room.name 컬럼에는 parsed clean_name이 저장됨
+--       suffix 형식: "1번룸 (평일 낮)", "1번룸 (주말)" 등
+--       (room_collection_service.py L1118: parsed.get("clean_name") or room["name"])
+--
+-- 실행 순서: Step 0(검증) → Step 1(삭제)
+-- Step 0은 SELECT 전용 — 결과 확인 후 Step 1 진행
+
+
+-- ────────────────────────────────────────────────
+-- Step 0: 삭제 대상 사전 확인 (실행 후 결과 검토 필수)
+-- 동일 business_id 내에서 base_name이 동일한 weekday/weekend 쌍을 찾아 weekend를 대상으로 조회
+-- ────────────────────────────────────────────────
+SELECT
+    we.biz_item_id   AS orphan_biz_item_id,
+    we.name          AS orphan_name,
+    wd.biz_item_id   AS primary_biz_item_id,
+    wd.name          AS primary_name,
+    we.business_id
+FROM room we
+JOIN room wd
+  ON wd.business_id = we.business_id
+ AND regexp_replace(wd.name, '\s*\((?:평일\s*낮|평일\s*오전|평일\s*야간|평일)\)\s*$', '')
+   = regexp_replace(we.name, '\s*\((?:주말[^)]*|공휴일)\)\s*$', '')
+ AND wd.biz_item_id <> we.biz_item_id
+WHERE we.name ~ '\((?:주말|주말/공휴일|공휴일)'
+  AND wd.name ~ '\((?:평일'
+ORDER BY we.business_id, we.name;
+
+
+-- ────────────────────────────────────────────────
+-- Step 1: 고아 주말 variant 룸 삭제
+-- Step 0 결과를 확인한 뒤 실행하세요.
+-- ────────────────────────────────────────────────
+BEGIN;
+
+DELETE FROM room
+WHERE biz_item_id IN (
+    SELECT we.biz_item_id
+    FROM room we
+    JOIN room wd
+      ON wd.business_id = we.business_id
+     AND regexp_replace(wd.name, '\s*\((?:평일\s*낮|평일\s*오전|평일\s*야간|평일)\)\s*$', '')
+       = regexp_replace(we.name, '\s*\((?:주말[^)]*|공휴일)\)\s*$', '')
+     AND wd.biz_item_id <> we.biz_item_id
+    WHERE we.name ~ '\((?:주말|주말/공휴일|공휴일)'
+      AND wd.name ~ '\((?:평일'
+);
+
+-- 삭제 건수 확인
+SELECT 'deleted orphan variant rooms' AS action, COUNT(*) AS remaining_weekend_variants
+FROM room
+WHERE name ~ '\((?:주말|주말/공휴일|공휴일)';
+
+COMMIT;

--- a/tests/services/test_room_collection_day_variant_merge.py
+++ b/tests/services/test_room_collection_day_variant_merge.py
@@ -1,0 +1,212 @@
+# tests/services/test_room_collection_day_variant_merge.py
+"""
+RoomCollectionService 요일 variant 병합 로직 단위 테스트 (#259)
+
+테스트 대상:
+- _get_base_room_name
+- _classify_day_variant
+- _merge_day_variant_rooms
+
+실행: pytest tests/services/test_room_collection_day_variant_merge.py -v
+"""
+
+import pytest
+from unittest.mock import patch
+
+
+@pytest.fixture
+def service():
+    with patch("app.services.room_collection_service.NaverMapCrawler"), \
+         patch("app.services.room_collection_service.NaverRoomFetcher"), \
+         patch("app.services.room_collection_service.RoomParserService"), \
+         patch("app.services.room_collection_service.get_supabase_client"):
+        from app.services.room_collection_service import RoomCollectionService
+        return RoomCollectionService()
+
+
+def _room(biz_item_id: str, name: str, price: int = 10000) -> dict:
+    return {"bizItemId": biz_item_id, "name": name, "price": price}
+
+
+def _parsed(clean_name: str, day_type=None, max_cap=5, rec_cap=3, price_config=None) -> dict:
+    return {
+        "clean_name": clean_name,
+        "day_type": day_type,
+        "max_capacity": max_cap,
+        "recommend_capacity": rec_cap,
+        "recommend_capacity_range": [rec_cap - 1, rec_cap + 1],
+        "price_config": price_config or {},
+    }
+
+
+# ── _get_base_room_name ────────────────────────────────────────────────────────
+
+class TestGetBaseRoomName:
+    def test_strips_weekday_suffix(self, service):
+        assert service._get_base_room_name("1번룸 (평일 낮)") == "1번룸"
+
+    def test_strips_weekend_suffix(self, service):
+        assert service._get_base_room_name("1번룸 (주말)") == "1번룸"
+
+    def test_strips_time_only_suffix(self, service):
+        assert service._get_base_room_name("1번룸 (심야)") == "1번룸"
+
+    def test_no_suffix_unchanged(self, service):
+        assert service._get_base_room_name("1번룸") == "1번룸"
+
+    def test_empty_string(self, service):
+        assert service._get_base_room_name("") == ""
+
+
+# ── _classify_day_variant ──────────────────────────────────────────────────────
+
+class TestClassifyDayVariant:
+    def test_day_type_weekday(self, service):
+        assert service._classify_day_variant("1번룸", "weekday") == "weekday"
+
+    def test_day_type_weekend(self, service):
+        assert service._classify_day_variant("1번룸", "weekend") == "weekend"
+
+    def test_weekday_suffix_no_day_type(self, service):
+        assert service._classify_day_variant("1번룸 (평일 낮)", None) == "weekday"
+
+    def test_weekend_suffix_no_day_type(self, service):
+        assert service._classify_day_variant("1번룸 (주말)", None) == "weekend"
+
+    def test_time_only_suffix_returns_none(self, service):
+        """심야/야간/주간은 요일 정보 없음 → 병합 대상 제외"""
+        assert service._classify_day_variant("1번룸 (심야)", None) is None
+        assert service._classify_day_variant("1번룸 (야간)", None) is None
+        assert service._classify_day_variant("1번룸 (주간)", None) is None
+
+    def test_no_suffix_no_day_type_returns_none(self, service):
+        assert service._classify_day_variant("1번룸", None) is None
+
+
+# ── _merge_day_variant_rooms ───────────────────────────────────────────────────
+
+class TestMergeDayVariantRooms:
+
+    def test_normal_merge_weekday_weekend(self, service):
+        """정상 병합: weekday 1 + weekend 1 → 단일 룸"""
+        rooms = [
+            _room("wd-1", "[평일 낮] 1번룸", price=10000),
+            _room("we-1", "[주말] 1번룸", price=15000),
+        ]
+        parsed = {
+            "wd-1": _parsed("1번룸 (평일 낮)", day_type=None, max_cap=5),
+            "we-1": _parsed("1번룸", day_type="weekend", max_cap=5),
+        }
+        merged_rooms, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+
+        assert len(merged_rooms) == 1
+        assert merged_rooms[0]["bizItemId"] == "wd-1"
+        assert merged_parsed["wd-1"]["clean_name"] == "1번룸"
+        assert merged_parsed["wd-1"]["day_type"] is None
+
+    def test_price_config_weekend_override_added(self, service):
+        """주말 가격이 다를 때 weekend override가 price_config에 추가됨"""
+        rooms = [
+            _room("wd-1", "[평일 낮] 1번룸", price=10000),
+            _room("we-1", "[주말] 1번룸", price=15000),
+        ]
+        parsed = {
+            "wd-1": _parsed("1번룸 (평일 낮)", day_type=None),
+            "we-1": _parsed("1번룸", day_type="weekend"),
+        }
+        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        cfg = merged_parsed["wd-1"]["price_config"]
+
+        assert cfg["default"] == 10000
+        weekend_override = next(o for o in cfg["overrides"] if o["day_type"] == "weekend")
+        assert weekend_override["price"] == 15000
+
+    def test_existing_surcharges_preserved(self, service):
+        """기존 surcharges가 병합 후에도 보존됨"""
+        existing_cfg = {
+            "default": 10000,
+            "overrides": [],
+            "surcharges": [{"day_type": "weekday", "amount": 2000}],
+        }
+        rooms = [
+            _room("wd-1", "[평일 낮] 1번룸", price=10000),
+            _room("we-1", "[주말] 1번룸", price=15000),
+        ]
+        parsed = {
+            "wd-1": _parsed("1번룸 (평일 낮)", day_type=None, price_config=existing_cfg),
+            "we-1": _parsed("1번룸", day_type="weekend"),
+        }
+        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        cfg = merged_parsed["wd-1"]["price_config"]
+
+        assert cfg["surcharges"] == [{"day_type": "weekday", "amount": 2000}]
+
+    def test_capacity_takes_higher_value(self, service):
+        """주말 max_capacity가 더 높으면 주말 값으로 덮어씀"""
+        rooms = [
+            _room("wd-1", "[평일 낮] 1번룸", price=10000),
+            _room("we-1", "[주말] 1번룸", price=10000),
+        ]
+        parsed = {
+            "wd-1": _parsed("1번룸 (평일 낮)", day_type=None, max_cap=5, rec_cap=3),
+            "we-1": _parsed("1번룸", day_type="weekend", max_cap=8, rec_cap=5),
+        }
+        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+
+        assert merged_parsed["wd-1"]["max_capacity"] == 8
+        assert merged_parsed["wd-1"]["recommend_capacity"] == 5
+
+    def test_recommend_capacity_none_not_overwritten(self, service):
+        """주말 recommend_capacity가 None이면 평일 값 유지"""
+        rooms = [
+            _room("wd-1", "[평일 낮] 1번룸", price=10000),
+            _room("we-1", "[주말] 1번룸", price=10000),
+        ]
+        parsed = {
+            "wd-1": _parsed("1번룸 (평일 낮)", day_type=None, max_cap=5, rec_cap=3),
+            "we-1": {
+                "clean_name": "1번룸",
+                "day_type": "weekend",
+                "max_capacity": 8,
+                "recommend_capacity": None,
+                "recommend_capacity_range": None,
+                "price_config": {},
+            },
+        }
+        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+
+        # we_max(8) > wd_max(5)이지만 we_rec=None → recommend_capacity 유지 안 됨 확인
+        assert merged_parsed["wd-1"]["max_capacity"] == 8
+        assert merged_parsed["wd-1"]["recommend_capacity"] == 3  # 평일 값 유지
+
+    def test_merge_skipped_when_three_variants(self, service):
+        """3개 이상 variant → 병합 조건 미충족, 모두 원형 유지"""
+        rooms = [
+            _room("r-1", "[평일 낮] 1번룸", price=10000),
+            _room("r-2", "[주말] 1번룸", price=15000),
+            _room("r-3", "1번룸", price=12000),
+        ]
+        parsed = {
+            "r-1": _parsed("1번룸 (평일 낮)", day_type=None),
+            "r-2": _parsed("1번룸", day_type="weekend"),
+            "r-3": _parsed("1번룸", day_type=None),
+        }
+        merged_rooms, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+
+        assert len(merged_rooms) == 3
+
+    def test_merge_skipped_when_price_missing(self, service):
+        """wd_price 또는 we_price가 None이면 price_config 미생성"""
+        rooms = [
+            _room("wd-1", "[평일 낮] 1번룸", price=0),
+            _room("we-1", "[주말] 1번룸", price=15000),
+        ]
+        rooms[0].pop("price")
+        parsed = {
+            "wd-1": _parsed("1번룸 (평일 낮)", day_type=None),
+            "we-1": _parsed("1번룸", day_type="weekend"),
+        }
+        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+
+        # price_config은 원래 평일 값(빈 dict) 유지
+        assert merged_parsed["wd-1"].get("price_config") == {}

--- a/tests/services/test_room_collection_day_variant_merge.py
+++ b/tests/services/test_room_collection_day_variant_merge.py
@@ -191,9 +191,50 @@ class TestMergeDayVariantRooms:
             "r-2": _parsed("1번룸", day_type="weekend"),
             "r-3": _parsed("1번룸", day_type=None),
         }
-        merged_rooms, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        merged_rooms, _merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
 
         assert len(merged_rooms) == 3
+
+    def test_no_price_config_when_equal_prices(self, service):
+        """평일 == 주말 가격이면 weekend override 미생성"""
+        rooms = [
+            _room("wd-1", "[평일 낮] 1번룸", price=10000),
+            _room("we-1", "[주말] 1번룸", price=10000),
+        ]
+        parsed = {
+            "wd-1": _parsed("1번룸 (평일 낮)", day_type=None),
+            "we-1": _parsed("1번룸", day_type="weekend"),
+        }
+        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        cfg = merged_parsed["wd-1"]["price_config"]
+
+        assert cfg == {}
+
+    def test_existing_weekday_override_preserved(self, service):
+        """기존 weekday override가 병합 후에도 보존됨"""
+        existing_cfg = {
+            "default": 10000,
+            "overrides": [{"day_type": "weekday", "start_hour": "18:00", "end_hour": "24:00", "price": 12000}],
+            "surcharges": [],
+        }
+        rooms = [
+            _room("wd-1", "[평일 낮] 1번룸", price=10000),
+            _room("we-1", "[주말] 1번룸", price=15000),
+        ]
+        parsed = {
+            "wd-1": _parsed("1번룸 (평일 낮)", day_type=None, price_config=existing_cfg),
+            "we-1": _parsed("1번룸", day_type="weekend"),
+        }
+        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        cfg = merged_parsed["wd-1"]["price_config"]
+        overrides = cfg["overrides"]
+
+        weekday_override = next((o for o in overrides if o["day_type"] == "weekday"), None)
+        assert weekday_override is not None
+        assert weekday_override["price"] == 12000
+        weekend_override = next((o for o in overrides if o["day_type"] == "weekend"), None)
+        assert weekend_override is not None
+        assert weekend_override["price"] == 15000
 
     def test_merge_skipped_when_price_missing(self, service):
         """wd_price 또는 we_price가 None이면 price_config 미생성"""

--- a/tests/services/test_room_collection_day_variant_merge.py
+++ b/tests/services/test_room_collection_day_variant_merge.py
@@ -35,7 +35,7 @@ def _parsed(clean_name: str, day_type=None, max_cap=5, rec_cap=3, price_config=N
         "max_capacity": max_cap,
         "recommend_capacity": rec_cap,
         "recommend_capacity_range": [rec_cap - 1, rec_cap + 1],
-        "price_config": price_config or {},
+        "price_config": price_config if price_config is not None else {},
     }
 
 
@@ -255,7 +255,7 @@ class TestMergeDayVariantRooms:
         assert merged_parsed["wd-1"].get("price_config") == {}
 
     def test_three_pairs_six_to_three_rooms(self, service):
-        """3개 base_name × (weekday + weekend) = 6룸 → 3룸 병합 (business_id=1227688 시나리오)"""
+        """3개 base_name x (weekday + weekend) = 6룸 → 3룸 병합 (business_id=1227688 시나리오)"""
         rooms = [
             _room("wd-1", "[평일] 1번룸", price=10000),
             _room("we-1", "[주말] 1번룸", price=15000),

--- a/tests/services/test_room_collection_day_variant_merge.py
+++ b/tests/services/test_room_collection_day_variant_merge.py
@@ -97,12 +97,13 @@ class TestMergeDayVariantRooms:
             "wd-1": _parsed("1번룸 (평일 낮)", day_type=None, max_cap=5),
             "we-1": _parsed("1번룸", day_type="weekend", max_cap=5),
         }
-        merged_rooms, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        merged_rooms, merged_parsed, dropped_ids = service._merge_day_variant_rooms(rooms, parsed)
 
         assert len(merged_rooms) == 1
         assert merged_rooms[0]["bizItemId"] == "wd-1"
         assert merged_parsed["wd-1"]["clean_name"] == "1번룸"
         assert merged_parsed["wd-1"]["day_type"] is None
+        assert dropped_ids == ["we-1"]
 
     def test_price_config_weekend_override_added(self, service):
         """주말 가격이 다를 때 weekend override가 price_config에 추가됨"""
@@ -114,7 +115,7 @@ class TestMergeDayVariantRooms:
             "wd-1": _parsed("1번룸 (평일 낮)", day_type=None),
             "we-1": _parsed("1번룸", day_type="weekend"),
         }
-        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        _, merged_parsed, _ = service._merge_day_variant_rooms(rooms, parsed)
         cfg = merged_parsed["wd-1"]["price_config"]
 
         assert cfg["default"] == 10000
@@ -136,7 +137,7 @@ class TestMergeDayVariantRooms:
             "wd-1": _parsed("1번룸 (평일 낮)", day_type=None, price_config=existing_cfg),
             "we-1": _parsed("1번룸", day_type="weekend"),
         }
-        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        _, merged_parsed, _ = service._merge_day_variant_rooms(rooms, parsed)
         cfg = merged_parsed["wd-1"]["price_config"]
 
         assert cfg["surcharges"] == [{"day_type": "weekday", "amount": 2000}]
@@ -151,7 +152,7 @@ class TestMergeDayVariantRooms:
             "wd-1": _parsed("1번룸 (평일 낮)", day_type=None, max_cap=5, rec_cap=3),
             "we-1": _parsed("1번룸", day_type="weekend", max_cap=8, rec_cap=5),
         }
-        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        _, merged_parsed, _ = service._merge_day_variant_rooms(rooms, parsed)
 
         assert merged_parsed["wd-1"]["max_capacity"] == 8
         assert merged_parsed["wd-1"]["recommend_capacity"] == 5
@@ -173,7 +174,7 @@ class TestMergeDayVariantRooms:
                 "price_config": {},
             },
         }
-        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        _, merged_parsed, _ = service._merge_day_variant_rooms(rooms, parsed)
 
         # we_max(8) > wd_max(5)이지만 we_rec=None → recommend_capacity 유지 안 됨 확인
         assert merged_parsed["wd-1"]["max_capacity"] == 8
@@ -191,9 +192,10 @@ class TestMergeDayVariantRooms:
             "r-2": _parsed("1번룸", day_type="weekend"),
             "r-3": _parsed("1번룸", day_type=None),
         }
-        merged_rooms, _merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        merged_rooms, _merged_parsed, dropped_ids = service._merge_day_variant_rooms(rooms, parsed)
 
         assert len(merged_rooms) == 3
+        assert dropped_ids == []  # 병합 미발생 → 드롭 없음
 
     def test_no_price_config_when_equal_prices(self, service):
         """평일 == 주말 가격이면 weekend override 미생성"""
@@ -205,7 +207,7 @@ class TestMergeDayVariantRooms:
             "wd-1": _parsed("1번룸 (평일 낮)", day_type=None),
             "we-1": _parsed("1번룸", day_type="weekend"),
         }
-        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        _, merged_parsed, _ = service._merge_day_variant_rooms(rooms, parsed)
         cfg = merged_parsed["wd-1"]["price_config"]
 
         assert cfg == {}
@@ -225,7 +227,7 @@ class TestMergeDayVariantRooms:
             "wd-1": _parsed("1번룸 (평일 낮)", day_type=None, price_config=existing_cfg),
             "we-1": _parsed("1번룸", day_type="weekend"),
         }
-        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        _, merged_parsed, _ = service._merge_day_variant_rooms(rooms, parsed)
         cfg = merged_parsed["wd-1"]["price_config"]
         overrides = cfg["overrides"]
 
@@ -247,7 +249,52 @@ class TestMergeDayVariantRooms:
             "wd-1": _parsed("1번룸 (평일 낮)", day_type=None),
             "we-1": _parsed("1번룸", day_type="weekend"),
         }
-        _, merged_parsed = service._merge_day_variant_rooms(rooms, parsed)
+        _, merged_parsed, _ = service._merge_day_variant_rooms(rooms, parsed)
 
         # price_config은 원래 평일 값(빈 dict) 유지
         assert merged_parsed["wd-1"].get("price_config") == {}
+
+    def test_three_pairs_six_to_three_rooms(self, service):
+        """3개 base_name × (weekday + weekend) = 6룸 → 3룸 병합 (business_id=1227688 시나리오)"""
+        rooms = [
+            _room("wd-1", "[평일] 1번룸", price=10000),
+            _room("we-1", "[주말] 1번룸", price=15000),
+            _room("wd-2", "[평일] 2번룸", price=10000),
+            _room("we-2", "[주말] 2번룸", price=15000),
+            _room("wd-3", "[평일] 3번룸", price=10000),
+            _room("we-3", "[주말] 3번룸", price=15000),
+        ]
+        parsed = {
+            "wd-1": _parsed("1번룸 (평일 낮)", day_type=None),
+            "we-1": _parsed("1번룸", day_type="weekend"),
+            "wd-2": _parsed("2번룸 (평일 낮)", day_type=None),
+            "we-2": _parsed("2번룸", day_type="weekend"),
+            "wd-3": _parsed("3번룸 (평일 낮)", day_type=None),
+            "we-3": _parsed("3번룸", day_type="weekend"),
+        }
+        merged_rooms, _, dropped_ids = service._merge_day_variant_rooms(rooms, parsed)
+
+        assert len(merged_rooms) == 3
+        assert set(r["bizItemId"] for r in merged_rooms) == {"wd-1", "wd-2", "wd-3"}
+        assert set(dropped_ids) == {"we-1", "we-2", "we-3"}
+
+    def test_list_price_config_surcharges_not_carried(self, service):
+        """기존 price_config가 list 타입이면 surcharges는 [] 처리됨 (list 포맷에는 surcharges 키 없음)"""
+        existing_cfg = [
+            {"day_type": "weekday", "price_per_hour": 10000},
+        ]
+        rooms = [
+            _room("wd-1", "[평일 낮] 1번룸", price=10000),
+            _room("we-1", "[주말] 1번룸", price=15000),
+        ]
+        parsed = {
+            "wd-1": _parsed("1번룸 (평일 낮)", day_type=None, price_config=existing_cfg),
+            "we-1": _parsed("1번룸", day_type="weekend"),
+        }
+        _, merged_parsed, _ = service._merge_day_variant_rooms(rooms, parsed)
+        cfg = merged_parsed["wd-1"]["price_config"]
+
+        # list 타입은 isinstance(existing_cfg, dict) = False → surcharges = []
+        assert cfg["surcharges"] == []
+        # weekend override는 정상 추가됨
+        assert any(o.get("day_type") == "weekend" for o in cfg["overrides"])


### PR DESCRIPTION
# 개요
  동일한 물리적 룸이 평일/주말 별도 biz_item_id로 2개 행 저장되는 케이스를 수집 파이프라인에서 탐지하고 단일 룸으로 병합합니다.

 # 배경
  [평일 낮] 1번룸, [주말] 1번룸처럼 요일별로 분리된 룸이 DB에 별도 행으로 존재하면 사용자에게 같은 룸이 중복 노출됩니다. 대표 케이스: business_id=1227688 (6건).

##  변경 사항 — room_collection_service.py

  추가된 메서드 3개
```
  _get_base_room_name(clean_name) — 시간대/요일 suffix 제거
  # "1번룸 (평일 낮)" → "1번룸"
  # "1번룸 (주말)"   → "1번룸"
  _DAY_VARIANT_SUFFIX_RE = re.compile(
      r"\s*\((?:평일\s*낮|평일\s*오전|평일\s*야간|주말/공휴일|평일|주말|공휴일|심야|야간|주간)\)\s*$"
  )
```

  _classify_day_variant(clean_name, day_type) — 평일/주말 판별
  - day_type 필드 우선, 없으면 clean_name suffix 패턴으로 판별
  - [평일 낮]처럼 파서가 day_type=None으로 반환하는 케이스도 suffix로 커버

  _merge_day_variant_rooms(rooms, parsed_results) — 병합 처리

  병합 조건: 동일 base_name 그룹 내 weekday 1개 + weekend 1개 (기타 없음)

  병합 결과:
  - 대표 룸: 평일 룸 (weekday)의 biz_item_id 유지
  - capacity: 평일/주말 중 높은 값 사용
  - price_config: 주말 가격이 다를 경우 weekend override 자동 생성
```
  {
      "default": wd_price,
      "overrides": [{"day_type": "weekend", "start_hour": "00:00", "end_hour": "24:00", "price": we_price}],
      "surcharges": []
  }
```
  - 조건 미충족 시 모든 룸 원형 유지 (안전 방향)

  호출부 삽입

```
  # 파싱 완료 → 병합 → DB 저장
  parsed_results = await self._parse_with_concurrency(parse_items)
  target_rooms, parsed_results = self._merge_day_variant_rooms(target_rooms, parsed_results)  # 추가
  saved = await self._save_to_db(...)
```

# 주의 사항
  - DB 잔존 행 정리 필요: 병합 후 주말 룸의 biz_item_id는 더 이상 크롤 대상이 되지 않아 DB에 고아 행으로 남습니다. 별도 마이그레이션으로 삭제 또는 soft-delete 처리가 필요합니다. (후속 이슈로 관리)
  - 기존 DB 즉시 반영 안 됨: 코드 배포 후 해당 지점이 재크롤될 때 병합이 적용됩니다. 즉시 반영이 필요하면 수동 재크롤 트리거 필요.
  - 병합 조건(weekday 1 + weekend 1)을 충족하지 않는 케이스(예: 평일 2개, 또는 3개 이상)는 병합하지 않고 기존 동작 유지

# 체크리스트

  - business_id=1227688 재크롤 후 6건 → 3건으로 줄어드는지 확인
  - 병합된 룸의 price_config에 weekday/weekend 가격이 모두 포함되었는지 확인
  - 병합 조건 미충족 케이스(3개 이상 variant, 혼합)에서 기존 룸 수 유지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Consolidates weekday/weekend room variants with the same base name into a single displayed room, preserving higher capacity, weekend price overrides, and existing surcharges; skips merging when more than two variants exist.

* **Chores**
  * Automatically removes orphaned weekend variant rows after successful saves; adds a migration to identify and clean existing orphaned variant rows with a safe verification step.

* **Tests**
  * Added unit tests covering base-name detection, day-variant classification, merge behavior, capacity selection, price-override handling, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->