### PR TITLE
[#264]; refactor: _calculate_capacity_range Fail-Fast 적용 및 허구 범위 생성 경로 제거

### DIFF
--- a/app/constants.py
+++ b/app/constants.py
@@ -1,0 +1,5 @@
+# 수동 검토 플래그 값 — 인원수 파싱 실패 시 할당되는 sentinel 값
+# 합주실 최대 수용 인원이 100명을 초과하는 경우는 현실적으로 없으므로
+# 이 값이 DB에 저장된 경우 수동 검토 대상으로 식별한다.
+# RoomDetail.MANUAL_REVIEW_CAPACITY_FLAG, RoomCollectionService.MANUAL_REVIEW_FLAG 와 동기화
+MANUAL_REVIEW_CAPACITY_FLAG: int = 100

--- a/app/models/dto.py
+++ b/app/models/dto.py
@@ -131,14 +131,11 @@ class RoomDetail(BaseModel):
         ):
             self.recommendCapacityRange = None
 
-        # ③ [#257] 레거시 sentinel clamp(100→50) 잔재 및 상한 초과 방어 (실제 maxCapacity 기준)
+        # ③ 상한 초과 방어 (실제 maxCapacity 기준)
         if self.recommendCapacityRange and len(self.recommendCapacityRange) == 2:
             lo, hi = self.recommendCapacityRange
-            # [50,50]: MANUAL_REVIEW_FLAG(100)이 50으로 clamp된 레거시 산물
-            if lo == 50 and hi == 50:
-                self.recommendCapacityRange = None
             # 상한이 max_capacity 초과: max_capacity 기준으로 clamp, 하한 최솟값 1 보장
-            elif self.maxCapacity > 0 and hi > self.maxCapacity:
+            if self.maxCapacity > 0 and hi > self.maxCapacity:
                 self.recommendCapacityRange = [max(1, min(lo, self.maxCapacity)), self.maxCapacity]
 
         # [이슈 6] recommendCapacity(단일값) fallback 로직 제거.

--- a/app/models/dto.py
+++ b/app/models/dto.py
@@ -3,6 +3,7 @@ from datetime import datetime, date
 from pydantic import BaseModel, Field, ConfigDict, field_validator, model_validator, AliasChoices
 import logging
 from typing import List, Dict, Union, Any, Optional, ClassVar, Literal
+from app.constants import MANUAL_REVIEW_CAPACITY_FLAG as _MANUAL_REVIEW_CAPACITY_FLAG
 
 class HealthResponse(BaseModel):
     """Health Check Response Model"""
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 class RoomDetail(BaseModel):
     """Room detail information (DB column mapping with branch join)"""
     model_config = ConfigDict(populate_by_name=True)
-    MANUAL_REVIEW_CAPACITY_FLAG: ClassVar[int] = 100
+    MANUAL_REVIEW_CAPACITY_FLAG: ClassVar[int] = _MANUAL_REVIEW_CAPACITY_FLAG
     BRANCH_FALLBACK_NAME: ClassVar[str] = "지점 정보 없음"
 
     # DB 컬럼명과 일치 (room 테이블 + branch(name) join)

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -15,6 +15,7 @@ from app.services.room_parser_service import RoomParserService
 from app.core.constants import PRIORITY_AREA_QUERIES
 from app.core.supabase_client import get_supabase_client
 from app.core.name_utils import normalize_name_token
+from app.constants import MANUAL_REVIEW_CAPACITY_FLAG as _MANUAL_REVIEW_CAPACITY_FLAG
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +29,8 @@ class RoomCollectionService:
     
     # Capacity value indicating parsing failure - flags for manual review
     # Rationale: 100명을 수용하는 합주실은 현실적으로 없으므로 수동 검토 필요 목적으로 식별 가능
-    MANUAL_REVIEW_FLAG = 100
+    # app.constants.MANUAL_REVIEW_CAPACITY_FLAG 와 동기화 (단일 선언)
+    MANUAL_REVIEW_FLAG = _MANUAL_REVIEW_CAPACITY_FLAG
     MAX_BUSINESS_DESC_CHARS = int(os.getenv("MAX_BUSINESS_DESC_CHARS", "1200"))
     PRICE_MATCH_TOLERANCE = 1000
     # 시간당 최소 가격 (원). 개인연습실(3,000~4,999원대) 자연 탈락 목적.
@@ -2128,14 +2130,25 @@ class RoomCollectionService:
 
         Rationale:
             1. 파싱된 범위가 유효하면 우선 사용 (단 합리적 범위로 clamp)
-            2. rec_cap, max_cap 모두 FLAG → None (근거 없음, 허구 생성 금지)
+            2. rec_cap >= FLAG → None (근거 없음, 허구 생성 금지)
+               - max_cap도 FLAG면 당연히 None
+               - rec_cap만 FLAG여도 step 4가 rec_cap 기반 계산을 하므로 None이 안전
             3. 추가 요금 발생 시 [effective_base_cap, effective_max_cap]
                단, base_cap이 FLAG면 effective_base_cap=None → step 4 fallback
+               max_cap이 FLAG면 effective_max_cap=0 → [base_cap, base_cap] 반환 (의도된 동작)
             4. 추가 요금 없을 시 [rec_cap - 1, rec_cap + 1] (최대 effective_max_cap)
 
-        Precondition (save_to_db 흐름 보장):
-            rec_cap >= FLAG 이면 max_cap >= FLAG. 역은 성립하지 않음 (Case 3).
+        Examples:
+            rec=4, max=8           → [3, 5]
+            rec=4, max=FLAG        → [3, 5]  (상한 없음)
+            rec=1, max=FLAG        → [1, 2]
+            rec=FLAG, max=FLAG     → None
+            rec=FLAG, max=5        → None    (Precondition 위반, 방어적 처리)
+            base=6, extra=5000, max=8      → [6, 8]
+            base=6, extra=5000, max=FLAG   → [6, 6]  (max 불명, base=base)
         """
+        # NOTE: effective_max_cap은 step 1(parsed_range clamp)에서도 사용하므로
+        #       Fail-Fast(step 2) 이전에 계산한다.
         # max_cap=0 은 FLAG와 동일하게 "미확인"으로 처리 → 상한 제약 없음
         effective_max_cap = max_cap if 0 < max_cap < self.MANUAL_REVIEW_FLAG else 0
 
@@ -2156,8 +2169,14 @@ class RoomCollectionService:
             clamped_max = max(clamped_max, clamped_min)
             return [clamped_min, clamped_max]
 
-        # 2. rec_cap, max_cap 모두 FLAG → 근거 없음, None 반환 (#264)
-        if rec_cap >= self.MANUAL_REVIEW_FLAG and max_cap >= self.MANUAL_REVIEW_FLAG:
+        # 2. rec_cap >= FLAG → 근거 없음, None 반환 (#264)
+        # rec_cap만 FLAG인 경우(Precondition 위반)도 방어적으로 None 반환
+        if rec_cap >= self.MANUAL_REVIEW_FLAG:
+            if max_cap < self.MANUAL_REVIEW_FLAG:
+                logger.warning(
+                    "[capacity_range] precondition violation: rec_cap=FLAG but max_cap=%d — returning None",
+                    max_cap,
+                )
             return None
 
         # base_cap FLAG 처리

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -2112,7 +2112,7 @@ class RoomCollectionService:
         max_cap: int,
         base_cap: Optional[int],
         extra_charge: Optional[int]
-    ) -> List[int]:
+    ) -> Optional[List[int]]:
         """추가 요금 유무에 따라 권장 인원 범위 계산
 
         Args:
@@ -2123,13 +2123,17 @@ class RoomCollectionService:
             extra_charge: 추가 요금 (원)
 
         Returns:
-            [min, max] 형태의 권장 인원 범위 리스트
+            [min, max] 형태의 권장 인원 범위 리스트. 근거 없으면 None.
 
         Rationale:
             1. 파싱된 범위가 유효하면 우선 사용 (단 합리적 범위로 clamp)
-            2. 추가 요금 발생 시 [base_cap, max_cap]
-            3. 추가 요금 없을 시 [rec_cap, rec_cap + 2] (최대 max_cap)
+            2. rec_cap, max_cap 모두 FLAG → None (근거 없음, 허구 생성 금지)
+            3. 추가 요금 발생 시 [base_cap, max_cap]
+            4. 추가 요금 없을 시 [rec_cap - 1, rec_cap + 1] (최대 max_cap)
         """
+        # max_cap이 FLAG면 상한 제약 없음으로 처리
+        effective_max_cap = max_cap if 0 < max_cap < self.MANUAL_REVIEW_FLAG else 0
+
         # 1. 파싱된 범위 검증 후 우선 사용
         # 조건: 2개 숫자(int 또는 float), min <= max, 합주실 현실적 범위(1~50명 이내)
         # NOTE: 파서가 float(예: 4.0)을 반환할 수 있으므로 int/float 모두 허용
@@ -2142,38 +2146,34 @@ class RoomCollectionService:
         ):
             # float → int 변환 및 합리적 범위로 clamp
             clamped_min = max(int(parsed_range[0]), 1)
-            clamped_max = min(int(parsed_range[1]), max_cap) if max_cap > 0 else int(parsed_range[1])
+            clamped_max = min(int(parsed_range[1]), effective_max_cap) if effective_max_cap > 0 else int(parsed_range[1])
             # clamp 후에도 min <= max 보장
             clamped_max = max(clamped_max, clamped_min)
             return [clamped_min, clamped_max]
 
-        # --- Sentinel 방어 ---
-        # NOTE: MANUAL_REVIEW_FLAG(100)이 rec_cap/max_cap/base_cap에 들어오면
-        #        [100, 102] 같은 비현실적 범위가 반환되므로 현실적 상한(50)으로 clamp
-        MAX_REALISTIC_CAP = 50
-        if max_cap >= self.MANUAL_REVIEW_FLAG:
-            max_cap = MAX_REALISTIC_CAP
-        if rec_cap >= self.MANUAL_REVIEW_FLAG:
-            rec_cap = MAX_REALISTIC_CAP
-        if base_cap and base_cap >= self.MANUAL_REVIEW_FLAG:
-            base_cap = MAX_REALISTIC_CAP
+        # 2. rec_cap, max_cap 모두 FLAG → 근거 없음, None 반환 (#264)
+        if rec_cap >= self.MANUAL_REVIEW_FLAG and max_cap >= self.MANUAL_REVIEW_FLAG:
+            return None
 
-        # 2. 추가 요금 있는 경우
-        if extra_charge and extra_charge > 0 and base_cap:
+        # base_cap FLAG 처리
+        effective_base_cap = base_cap if base_cap is not None and base_cap < self.MANUAL_REVIEW_FLAG else None
+
+        # 3. 추가 요금 있는 경우
+        if extra_charge and extra_charge > 0 and effective_base_cap:
             # min: base_cap, max: max_cap
             # 단 max_cap < base_cap인 비정상 데이터 방어
-            real_max = max(max_cap, base_cap)
-            return [base_cap, real_max]
-            
-        # 3. 추가 요금 없는 경우 (기본)
+            real_max = max(effective_max_cap, effective_base_cap) if effective_max_cap > 0 else effective_base_cap
+            return [effective_base_cap, real_max]
+
+        # 4. 추가 요금 없는 경우 (기본)
         # ±1 고정: rec_cap >= 9 시 ±2 분기는 max_cap에 걸려 단일값([x,x])이 되는 역효과가 있어 제거 (#258)
         delta = 1
         min_c = max(rec_cap - delta, 1)
-        max_c = min(rec_cap + delta, max_cap) if max_cap > 0 else rec_cap + delta
+        max_c = min(rec_cap + delta, effective_max_cap) if effective_max_cap > 0 else rec_cap + delta
 
         # min <= max 보장
         max_c = max(max_c, min_c)
-        
+
         return [min_c, max_c]
 
     async def _export_unresolved(self, business: Dict, rooms: List[Dict], parsed_results: Dict):

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -2191,6 +2191,12 @@ class RoomCollectionService:
             real_max = max(effective_max_cap, effective_base_cap) if effective_max_cap > 0 else effective_base_cap
             return [effective_base_cap, real_max]
 
+        # 3.5. 파서 기본값 sentinel: rec_cap=0, effective_max_cap=0 → 근거 없음, None 반환
+        # max_cap=0은 파서가 아무 값도 얻지 못했을 때의 기본값으로,
+        # step 4에서 [1, 1]을 생성하는 것은 FLAG 케이스와 동일한 허구 범위 문제.
+        if rec_cap == 0 and effective_max_cap == 0 and not parsed_range:
+            return None
+
         # 4. 추가 요금 없는 경우 (기본)
         # ±1 고정: rec_cap >= 9 시 ±2 분기는 max_cap에 걸려 단일값([x,x])이 되는 역효과가 있어 제거 (#258)
         delta = 1

--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -1128,6 +1128,7 @@ class RoomCollectionService:
                 "max_capacity": final_max_cap_int,
                 "recommend_capacity": final_rec_cap_int,
                 # [v2.0.0] 신규 필드: 권장 인원 범위 및 동적 가격 정책
+                # None 반환 시 Supabase 클라이언트가 NULL로 저장 (근거 없는 경우 의도적 NULL)
                 "recommend_capacity_range": self._calculate_capacity_range(
                     text_rec_range
                     or parsed.get("recommend_capacity_range")
@@ -2128,10 +2129,14 @@ class RoomCollectionService:
         Rationale:
             1. 파싱된 범위가 유효하면 우선 사용 (단 합리적 범위로 clamp)
             2. rec_cap, max_cap 모두 FLAG → None (근거 없음, 허구 생성 금지)
-            3. 추가 요금 발생 시 [base_cap, max_cap]
-            4. 추가 요금 없을 시 [rec_cap - 1, rec_cap + 1] (최대 max_cap)
+            3. 추가 요금 발생 시 [effective_base_cap, effective_max_cap]
+               단, base_cap이 FLAG면 effective_base_cap=None → step 4 fallback
+            4. 추가 요금 없을 시 [rec_cap - 1, rec_cap + 1] (최대 effective_max_cap)
+
+        Precondition (save_to_db 흐름 보장):
+            rec_cap >= FLAG 이면 max_cap >= FLAG. 역은 성립하지 않음 (Case 3).
         """
-        # max_cap이 FLAG면 상한 제약 없음으로 처리
+        # max_cap=0 은 FLAG와 동일하게 "미확인"으로 처리 → 상한 제약 없음
         effective_max_cap = max_cap if 0 < max_cap < self.MANUAL_REVIEW_FLAG else 0
 
         # 1. 파싱된 범위 검증 후 우선 사용
@@ -2156,6 +2161,8 @@ class RoomCollectionService:
             return None
 
         # base_cap FLAG 처리
+        # base_cap=FLAG 이면 effective_base_cap=None → step 3 조건 미충족 → step 4(rec_cap ±1) fallback
+        # extra_charge가 있더라도 기준 인원을 신뢰할 수 없으면 rec_cap 기반 추정이 차선책
         effective_base_cap = base_cap if base_cap is not None and base_cap < self.MANUAL_REVIEW_FLAG else None
 
         # 3. 추가 요금 있는 경우

--- a/docs/db-data-quality-spec.md
+++ b/docs/db-data-quality-spec.md
@@ -283,8 +283,9 @@ SELECT count(*) FROM room WHERE name ~ '\[.*(특가|할인|이벤트|EVENT).*\]'
 SELECT count(*) FROM branch WHERE lat IS NULL OR lng IS NULL;
 
 -- 5) 인원수 논리 위반 (recommend_capacity_range 기준)
+-- recommend_capacity_range는 integer[] 타입 (1-indexed: [1]=하한, [2]=상한)
 SELECT count(*) FROM room
-WHERE upper(recommend_capacity_range) > max_capacity
+WHERE (recommend_capacity_range IS NOT NULL AND recommend_capacity_range[2] > max_capacity)
    OR max_capacity > 50
    OR max_capacity <= 0;
 
@@ -311,5 +312,6 @@ WHERE name ~* '레슨|lesson|수업|클래스|원데이|기타 대여|베이스 
 
 -- 12) recommend_capacity_range 하한이 상한보다 큰 경우
 SELECT count(*) FROM room
-WHERE lower(recommend_capacity_range) > upper(recommend_capacity_range);
+WHERE recommend_capacity_range IS NOT NULL
+  AND recommend_capacity_range[1] > recommend_capacity_range[2];
 ```

--- a/tests/models/test_room_detail_v2.py
+++ b/tests/models/test_room_detail_v2.py
@@ -74,12 +74,17 @@ def test_alias_choices_precedence():
 
 # ── #257 capacity range 이상값 방어 테스트 ─────────────────────────────────────
 
-def test_recommend_capacity_range_sentinel_50_50_returns_none():
-    """[50,50]: MANUAL_REVIEW_FLAG(100)이 50으로 clamp된 레거시 산물 → None으로 정제"""
+def test_recommend_capacity_range_50_50_is_valid():
+    """[50,50]: #264 리팩터링 후 더 이상 생성되지 않는 값이나, DB 레거시로 남아있다면 유효 범위로 통과
+
+    AS-IS: FLAG(100)→50 sentinel clamp 잔재로 간주해 None 처리
+    TO-BE: _calculate_capacity_range에서 FLAG 입력 시 None 반환하므로 [50,50] 생성 경로 없음.
+           dto.py 안전망은 [100,100]→None만 유지. [50,50]은 그대로 통과.
+    """
     room = RoomDetail.model_validate(
-        _room_payload(max_capacity=8, recommend_capacity_range=[50, 50])
+        _room_payload(max_capacity=50, recommend_capacity_range=[50, 50])
     )
-    assert room.recommendCapacityRange is None
+    assert room.recommendCapacityRange == [50, 50]
 
 
 def test_recommend_capacity_range_upper_exceeds_max_is_clamped():

--- a/tests/services/test_room_collection_service.py
+++ b/tests/services/test_room_collection_service.py
@@ -369,8 +369,9 @@ class TestV2NewFields:
         TO-BE: 근거 없음 → None 반환 (#264)
 
         Rationale:
-            _save_to_db 경유 시 가격 밴드(5k~)가 항상 FLAG를 교체하므로
-            _calculate_capacity_range를 직접 호출해 단위 검증한다.
+            _save_to_db 경유 시 가격 밴드(5k~)가 항상 FLAG를 교체하므로 이 경로를
+            통합 테스트로 검증할 수 없다. 파이프라인 전제(유효 가격 필수)가 바뀌면
+            이 단위 테스트가 최후 방어선이 됨.
         """
         result = service._calculate_capacity_range(
             parsed_range=None,
@@ -396,6 +397,25 @@ class TestV2NewFields:
             extra_charge=None,
         )
         # rec=4, max_cap=FLAG(상한 없음) → [3, 5]
+        assert result == [3, 5]
+
+    # ============== TC: extra_charge 있으나 base_cap FLAG → rec_cap ±1 fallback (#264) ==============
+    def test_capacity_range_fallback_when_extra_charge_but_flag_base_cap(self, service):
+        """extra_charge가 있어도 base_cap이 FLAG(100)이면 effective_base_cap=None
+        → step 3 스킵 → rec_cap ±1 fallback
+
+        Rationale:
+            추가 요금 기준 인원을 신뢰할 수 없으면 [base_cap, max_cap] 형태 계산 불가.
+            rec_cap 기반 ±1이 차선책. 허구 base_cap으로 범위를 만들지 않는다.
+        """
+        result = service._calculate_capacity_range(
+            parsed_range=None,
+            rec_cap=4,
+            max_cap=8,
+            base_cap=100,       # FLAG
+            extra_charge=5000,
+        )
+        # base_cap=FLAG → effective_base_cap=None → step 3 스킵 → [3, 5]
         assert result == [3, 5]
 
     # ============== TC: range 없으면 ±1 Fallback ==============

--- a/tests/services/test_room_collection_service.py
+++ b/tests/services/test_room_collection_service.py
@@ -399,6 +399,40 @@ class TestV2NewFields:
         # rec=4, max_cap=FLAG(상한 없음) → [3, 5]
         assert result == [3, 5]
 
+    # ============== TC: rec_cap FLAG, max_cap 유효 → Precondition 위반 방어 (#264) ==============
+    def test_capacity_range_none_when_rec_cap_flag_only(self, service):
+        """rec_cap=FLAG, max_cap=유효 — Precondition 위반 케이스 방어적 None 반환
+
+        save_to_db 정상 흐름에서는 발생하지 않으나,
+        파서가 recommend_capacity=100을 직접 반환하는 경우 위반 가능.
+        rec_cap 기반 step 4 계산([99, 99])보다 None이 안전하다.
+        """
+        result = service._calculate_capacity_range(
+            parsed_range=None,
+            rec_cap=100,    # FLAG
+            max_cap=5,      # 유효값 — Precondition 위반
+            base_cap=None,
+            extra_charge=None,
+        )
+        assert result is None
+
+    # ============== TC: extra_charge + max_cap FLAG → [base_cap, base_cap] (P1-2) ==============
+    def test_capacity_range_single_value_when_extra_charge_and_flag_max_cap(self, service):
+        """extra_charge 유효 + base_cap 유효 + max_cap FLAG → [base_cap, base_cap]
+
+        max_cap이 FLAG면 effective_max_cap=0 → real_max = base_cap → [base_cap, base_cap].
+        상한을 알 수 없으나 기준 인원은 신뢰할 수 있는 경우의 의도된 동작.
+        """
+        result = service._calculate_capacity_range(
+            parsed_range=None,
+            rec_cap=4,
+            max_cap=100,    # FLAG
+            base_cap=6,
+            extra_charge=5000,
+        )
+        # effective_max_cap=0 → real_max = max(0, 6) if 0>0 else 6 = 6 → [6, 6]
+        assert result == [6, 6]
+
     # ============== TC: extra_charge 있으나 base_cap FLAG → rec_cap ±1 fallback (#264) ==============
     def test_capacity_range_fallback_when_extra_charge_but_flag_base_cap(self, service):
         """extra_charge가 있어도 base_cap이 FLAG(100)이면 effective_base_cap=None

--- a/tests/services/test_room_collection_service.py
+++ b/tests/services/test_room_collection_service.py
@@ -416,6 +416,22 @@ class TestV2NewFields:
         )
         assert result is None
 
+    # ============== TC: rec_cap=0, max_cap=0 → [1,1] 허구 범위 생성 방지 ==============
+    def test_capacity_range_none_when_both_zero(self, service):
+        """rec_cap=0, max_cap=0, parsed_range=None → None 반환 (허구 [1,1] 방지)
+
+        파서가 max_capacity=0을 반환하면 _save_to_db에서 FLAG로 올리지 않고 통과.
+        step 4에서 min_c=max(-1,1)=1, max_c=1 → [1,1] 이 생성되는 경로를 차단.
+        """
+        result = service._calculate_capacity_range(
+            parsed_range=None,
+            rec_cap=0,
+            max_cap=0,
+            base_cap=None,
+            extra_charge=None,
+        )
+        assert result is None
+
     # ============== TC: extra_charge + max_cap FLAG → [base_cap, base_cap] (P1-2) ==============
     def test_capacity_range_single_value_when_extra_charge_and_flag_max_cap(self, service):
         """extra_charge 유효 + base_cap 유효 + max_cap FLAG → [base_cap, base_cap]

--- a/tests/services/test_room_collection_service.py
+++ b/tests/services/test_room_collection_service.py
@@ -361,6 +361,43 @@ class TestV2NewFields:
         assert room_data["recommend_capacity_range"] == [4, 6]
         assert room_data["price_config"] == []
     
+    # ============== TC: rec_cap/max_cap 모두 FLAG → None 반환 (#264) ==============
+    def test_capacity_range_is_none_when_both_flag(self, service):
+        """rec_cap, max_cap 모두 FLAG(100)이면 None 반환
+
+        AS-IS: sentinel clamp(100→50) 후 delta 적용 → [49, 50] 같은 허구 범위 생성
+        TO-BE: 근거 없음 → None 반환 (#264)
+
+        Rationale:
+            _save_to_db 경유 시 가격 밴드(5k~)가 항상 FLAG를 교체하므로
+            _calculate_capacity_range를 직접 호출해 단위 검증한다.
+        """
+        result = service._calculate_capacity_range(
+            parsed_range=None,
+            rec_cap=100,
+            max_cap=100,
+            base_cap=None,
+            extra_charge=None,
+        )
+        assert result is None
+
+    # ============== TC: rec_cap 유효, max_cap FLAG → range 정상 계산 (#264) ==============
+    def test_capacity_range_computed_without_flag_max_cap(self, service):
+        """rec_cap은 유효하나 max_cap이 FLAG(100)인 경우, 상한 제약 없이 range 계산
+
+        AS-IS: FLAG max_cap을 50으로 clamp 후 delta 적용
+        TO-BE: FLAG max_cap은 상한 제약 없음으로 처리 → [rec-1, rec+1]
+        """
+        result = service._calculate_capacity_range(
+            parsed_range=None,
+            rec_cap=4,
+            max_cap=100,
+            base_cap=None,
+            extra_charge=None,
+        )
+        # rec=4, max_cap=FLAG(상한 없음) → [3, 5]
+        assert result == [3, 5]
+
     # ============== TC: range 없으면 ±1 Fallback ==============
     @pytest.mark.asyncio
     async def test_fallback_range_from_single_capacity(self, service, mock_supabase):


### PR DESCRIPTION
## 관련 이슈

closes #264

## 배경

PR #260 리뷰 중 `_calculate_capacity_range`에서 잠재적 허구 데이터 생성 경로 발견.
이상값 방어 패치(#257)가 3개 레이어에 걸쳐 산발적으로 추가되면서
sentinel 처리가 8곳에 분산되고, FLAG가 50으로 clamp된 뒤 delta 연산을 통해
근거 없는 범위(예: `[49, 50]`)가 생성될 수 있는 구조가 됐다.

현재 DB에 실제 이상값은 없으나(마이그레이션 검증 완료), 파이프라인 전제조건이
바뀌면 발화할 수 있어 구조적으로 제거한다.

## 변경 내용

### `_calculate_capacity_range` — Layer 2 판단 집중

**AS-IS**
```
rec_cap=100(FLAG), max_cap=100(FLAG)
  → sentinel clamp: 둘 다 50
  → delta 적용: [49, 50]  ← 허구 범위
  → dto.py [50,50]→None: 이 케이스를 잡지 못함
```

**TO-BE**
```
rec_cap=FLAG, max_cap=FLAG
  → None 반환 (근거 없으면 없는 정보로)
```

- 반환 타입 `List[int]` → `Optional[List[int]]`
- sentinel clamp(FLAG→50) 제거
- `rec_cap >= FLAG && max_cap >= FLAG` 조건 추가 → `None` 반환
- `max_cap=FLAG` 단독: `effective_max_cap=0`으로 처리해 상한 제약 없이 계산 (Case 3)
- `base_cap=FLAG`: `effective_base_cap=None`으로 처리 → extra_charge step 스킵 → rec_cap ±1 fallback

### `dto.py` — dead code 제거

- `[50,50]`→`None` 제거 (Layer 2 리팩터링으로 생성 경로 없어짐)
- `[100,100]`→`None` 안전망은 유지 (레거시 DB 데이터 대응)

## 케이스별 동작

| 입력 상태 | 변경 전 | 변경 후 |
|---|---|---|
| 권장 ✓ 최대 ✓ | 정상 범위 | 동일 |
| 권장 ✗ 최대 ✓ | max//2 기반 역산 | 동일 |
| 권장 ✓ 최대 ✗(FLAG) | range 정상, max 상한=50 고정 | range 정상, 상한 제약 없음 |
| 둘 다 ✗, 가격 ✓ | 가격 룰 적용 | 동일 |
| **둘 다 ✗, 가격 ✗** | **[49, 50] 허구 범위** | **None** |

## 테스트

- `test_capacity_range_is_none_when_both_flag`: 둘 다 FLAG → None
- `test_capacity_range_computed_without_flag_max_cap`: rec 유효 + max FLAG → 상한 없이 ±1
- `test_capacity_range_fallback_when_extra_charge_but_flag_base_cap`: extra_charge 있어도 base_cap=FLAG → rec_cap ±1 fallback
- `test_recommend_capacity_range_50_50_is_valid`: [50,50]이 더 이상 None으로 정제되지 않음 확인

> 단위 테스트로 직접 검증하는 이유: `_save_to_db` 경유 시 가격 밴드(5k~)가
> 항상 FLAG를 교체하므로 통합 경로로 Case 1-b를 재현할 수 없음.
> 파이프라인 전제가 바뀌면 이 단위 테스트가 최후 방어선.

## 체크리스트

- [x] 기존 정상 케이스 리그레션 없음 (432 passed)
- [x] `_calculate_capacity_range` 직접 호출 단위 테스트
- [x] precondition 주석 및 fallback 경로 주석
- [x] 프론트엔드 `recommend_capacity_range=null` 처리 — `frontend_guide.md`에 이미 명시됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recommend-capacity logic tightened: valid exact ranges (e.g., [50,50]) are preserved, max-limited cases are clamped correctly, and entries that require manual review or cannot be safely estimated may now be left unset to avoid incorrect suggestions.

* **Tests**
  * Added and updated tests covering manual-review, unknown/max-limited, and extra-charge edge cases.

* **Documentation**
  * Clarified data-quality validation checks and array indexing in docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->