### PR TITLE
[#268]; chore: recommend_capacity 컬럼 드롭 마이그레이션

### DIFF
--- a/app/services/room_collection_service.py
+++ b/app/services/room_collection_service.py
@@ -1027,7 +1027,6 @@ class RoomCollectionService:
                 "price_per_hour": final_price_int,
                 # Schema constraint: Default to 1 if null
                 "max_capacity": final_max_cap_int,
-                "recommend_capacity": min(final_max_cap_int, self.MANUAL_REVIEW_FLAG),  # CHECK(max>=rec) 준수, M5에서 드롭 (#268)
                 "recommend_capacity_range": self._calculate_capacity_range(
                     text_rec_range or parsed.get("recommend_capacity_range"),
                     final_max_cap_int,
@@ -1406,7 +1405,7 @@ class RoomCollectionService:
         """Extract high-confidence capacity signals from room name/desc text.
 
         Returns:
-            (max_capacity, recommend_capacity, recommend_capacity_range)
+            (max_capacity, rec_cap (unused, legacy), recommend_capacity_range)
         """
         name = room.get("name") or ""
         desc = room.get("desc") or ""

--- a/migrations/160_drop_recommend_capacity.sql
+++ b/migrations/160_drop_recommend_capacity.sql
@@ -1,0 +1,53 @@
+-- Migration 160: recommend_capacity 컬럼 및 CHECK 제약 드롭 (#268)
+--
+-- 배경:
+--   PR #272에서 recommend_capacity 단일값 파이프라인을 전면 제거하고
+--   recommend_capacity_range (배열)로 대체 완료. 컬럼에는 min(max_cap, FLAG)
+--   더미값만 저장되고 있어 실질적 의미 없음.
+--
+-- 삭제 대상:
+--   1. CHECK 제약: chk_room_cap_logic (max_capacity >= recommend_capacity)
+--   2. 컬럼: room.recommend_capacity
+--
+-- 전제 조건:
+--   - PR #272 배포 완료 (코드에서 recommend_capacity 키 제거된 상태)
+--   - 프론트엔드 recommend_capacity 미참조 확인 완료
+
+
+-- ────────────────────────────────────────────────
+-- [사전 검증] 현재 recommend_capacity 분포 확인
+-- 마이그레이션 실행 전 반드시 아래 SELECT를 먼저 실행하세요.
+-- ────────────────────────────────────────────────
+-- SELECT
+--     COUNT(*) AS total_rooms,
+--     COUNT(*) FILTER (WHERE recommend_capacity = max_capacity) AS dummy_min_clamp,
+--     COUNT(*) FILTER (WHERE recommend_capacity = 100) AS flag_100,
+--     COUNT(*) FILTER (WHERE recommend_capacity NOT IN (max_capacity, 100) AND recommend_capacity > 1) AS legacy_heuristic,
+--     COUNT(*) FILTER (WHERE recommend_capacity = 1) AS default_1
+-- FROM room;
+-- 기대값: legacy_heuristic = 0 (PR #272 배포 후 재크롤링 완료 시)
+
+
+BEGIN;
+
+-- 1. CHECK 제약 제거 (컬럼 드롭 전에 먼저)
+ALTER TABLE room DROP CONSTRAINT IF EXISTS chk_room_cap_logic;
+
+-- 2. recommend_capacity 컬럼 드롭
+ALTER TABLE room DROP COLUMN IF EXISTS recommend_capacity;
+
+COMMIT;
+
+
+-- ────────────────────────────────────────────────
+-- [사후 검증] COMMIT 후 별도 실행
+-- ────────────────────────────────────────────────
+-- SELECT column_name
+-- FROM information_schema.columns
+-- WHERE table_name = 'room' AND column_name = 'recommend_capacity';
+-- 기대값: 0건 (컬럼 삭제 확인)
+--
+-- SELECT conname
+-- FROM pg_constraint
+-- WHERE conrelid = 'room'::regclass AND conname = 'chk_room_cap_logic';
+-- 기대값: 0건 (제약조건 삭제 확인)

--- a/migrations/160_drop_recommend_capacity.sql
+++ b/migrations/160_drop_recommend_capacity.sql
@@ -26,6 +26,7 @@
 --     COUNT(*) FILTER (WHERE recommend_capacity = 1) AS default_1
 -- FROM room;
 -- 기대값: legacy_heuristic = 0 (PR #272 배포 후 재크롤링 완료 시)
+-- NOTE: legacy_heuristic > 0이어도 마이그레이션 실행 자체는 안전함 (데이터 의미만 소실)
 
 
 BEGIN;

--- a/tests/integration/test_room_collection_flow.py
+++ b/tests/integration/test_room_collection_flow.py
@@ -139,7 +139,7 @@ class TestCollectByIdFlow:
         assert room1_data["name"] in ("A룸", "[평일] A룸")
         assert room1_data["price_per_hour"] == 15000
         assert room1_data["max_capacity"] == 6
-        assert room1_data["recommend_capacity"] == 6  # min(max_cap, FLAG) — CHECK 제약 준수
+        assert "recommend_capacity" not in room1_data  # 컬럼 드롭 (#268)
         assert room1_data["base_capacity"] == 4
         assert room1_data["extra_charge"] == 3000
         assert len(room1_data["image_urls"]) == 2

--- a/tests/services/test_room_collection_day_variant_merge.py
+++ b/tests/services/test_room_collection_day_variant_merge.py
@@ -155,8 +155,8 @@ class TestMergeDayVariantRooms:
 
         assert merged_parsed["wd-1"]["max_capacity"] == 8
 
-    def test_recommend_capacity_none_not_overwritten(self, service):
-        """주말 recommend_capacity가 None이면 평일 값 유지"""
+    def test_recommend_capacity_range_preserved_when_weekend_none(self, service):
+        """주말 recommend_capacity_range가 None이면 평일 값 유지"""
         rooms = [
             _room("wd-1", "[평일 낮] 1번룸", price=10000),
             _room("we-1", "[주말] 1번룸", price=10000),

--- a/tests/services/test_room_collection_day_variant_merge.py
+++ b/tests/services/test_room_collection_day_variant_merge.py
@@ -33,7 +33,6 @@ def _parsed(clean_name: str, day_type=None, max_cap=5, rec_cap=3, price_config=N
         "clean_name": clean_name,
         "day_type": day_type,
         "max_capacity": max_cap,
-        "recommend_capacity": rec_cap,
         "recommend_capacity_range": [rec_cap - 1, rec_cap + 1],
         "price_config": price_config if price_config is not None else {},
     }
@@ -168,16 +167,14 @@ class TestMergeDayVariantRooms:
                 "clean_name": "1번룸",
                 "day_type": "weekend",
                 "max_capacity": 8,
-                "recommend_capacity": None,
                 "recommend_capacity_range": None,
                 "price_config": {},
             },
         }
         _, merged_parsed, _ = service._merge_day_variant_rooms(rooms, parsed)
 
-        # we_max(8) > wd_max(5)이지만 we_rec=None → recommend_capacity 유지 안 됨 확인
+        # we_max(8) > wd_max(5) → max는 병합, range는 we가 None이므로 wd 유지
         assert merged_parsed["wd-1"]["max_capacity"] == 8
-        assert merged_parsed["wd-1"]["recommend_capacity"] == 3  # 평일 값 유지
 
     def test_merge_skipped_when_three_variants(self, service):
         """3개 이상 variant → 병합 조건 미충족, 모두 원형 유지"""

--- a/tests/services/test_room_collection_service.py
+++ b/tests/services/test_room_collection_service.py
@@ -125,7 +125,7 @@ class TestDataPreservationLogic:
         upsert_data = upsert_call[0][0]
 
         assert upsert_data["max_capacity"] == 10
-        assert upsert_data["recommend_capacity"] == 10  # min(max_cap, FLAG) — CHECK 제약 준수
+        assert "recommend_capacity" not in upsert_data  # 컬럼 드롭 (#268)
     
     # ============== TC13: 새 값=5, 기존 값=10 → 새 값으로 업데이트 ==============
     @pytest.mark.asyncio
@@ -145,7 +145,7 @@ class TestDataPreservationLogic:
         upsert_data = upsert_call[0][0]
 
         assert upsert_data["max_capacity"] == 5
-        assert upsert_data["recommend_capacity"] == 5  # min(max_cap, FLAG) — CHECK 제약 준수
+        assert "recommend_capacity" not in upsert_data  # 컬럼 드롭 (#268)
     
     # ============== TC14: 새 값=8, 기존 값=1 → 새 값으로 업데이트 ==============
     @pytest.mark.asyncio
@@ -165,7 +165,7 @@ class TestDataPreservationLogic:
         upsert_data = upsert_call[0][0]
 
         assert upsert_data["max_capacity"] == 8
-        assert upsert_data["recommend_capacity"] == 8  # min(max_cap, FLAG) — CHECK 제약 준수
+        assert "recommend_capacity" not in upsert_data  # 컬럼 드롭 (#268)
     
     # ============== TC15: 기존 값 없음, 새 값=1 → 새 값 사용 ==============
     @pytest.mark.asyncio
@@ -183,7 +183,7 @@ class TestDataPreservationLogic:
         upsert_data = upsert_call[0][0]
 
         assert upsert_data["max_capacity"] == 1
-        assert upsert_data["recommend_capacity"] == 1  # min(max_cap, FLAG) — CHECK 제약 준수
+        assert "recommend_capacity" not in upsert_data  # 컬럼 드롭 (#268)
     
     # ============== TC: 가격 보존 로직 ==============
     @pytest.mark.asyncio

--- a/tests/services/test_room_collection_structured_priority.py
+++ b/tests/services/test_room_collection_structured_priority.py
@@ -205,7 +205,7 @@ async def test_text_capacity_signals_override_parser_capacity(service, mock_supa
     upsert_call = mock_supabase._room_table.upsert.call_args_list[-1]
     room_data = upsert_call[0][0]
     assert room_data["max_capacity"] == 30
-    assert room_data["recommend_capacity"] == 30  # min(max_cap, FLAG) — CHECK 제약 준수
+    assert "recommend_capacity" not in room_data  # 컬럼 드롭 (#268)
 
 
 @pytest.mark.asyncio
@@ -234,7 +234,7 @@ async def test_text_recommend_range_used_for_capacity_range(service, mock_supaba
     upsert_call = mock_supabase._room_table.upsert.call_args_list[-1]
     room_data = upsert_call[0][0]
     assert room_data["max_capacity"] == 8
-    assert room_data["recommend_capacity"] == 8  # min(max_cap, FLAG) — CHECK 제약 준수
+    assert "recommend_capacity" not in room_data  # 컬럼 드롭 (#268)
     assert room_data["recommend_capacity_range"] == [4, 8]
 
 
@@ -266,7 +266,7 @@ async def test_text_range_wins_when_both_text_and_parser_ranges_exist(service, m
     upsert_call = mock_supabase._room_table.upsert.call_args_list[-1]
     room_data = upsert_call[0][0]
     assert room_data["max_capacity"] == 8
-    assert room_data["recommend_capacity"] == 8  # min(max_cap, FLAG) — CHECK 제약 준수
+    assert "recommend_capacity" not in room_data  # 컬럼 드롭 (#268)
     assert room_data["recommend_capacity_range"] == [4, 8]
 
 


### PR DESCRIPTION
## Summary

- `recommend_capacity` 단일값 컬럼 및 CHECK 제약조건(`chk_room_cap_logic`) 드롭
- PR #272에서 코드 레벨 의존성 전면 제거 완료 → 이 PR에서 DB 스키마 정리
- `room_data` dict에서 `recommend_capacity` 키 제거, 테스트 assertion 갱신

## 배경

`recommend_capacity`는 레거시 단일값 필드로, `recommend_capacity_range` (배열)으로 대체 완료.
PR #272 머지 후 코드에서 더미값(`min(max_cap, FLAG)`)만 저장하고 있었으며,
프론트엔드에서도 미참조 상태.

## 변경 내역

| 파일 | 변경 |
|------|------|
| `migrations/160_drop_recommend_capacity.sql` | CHECK 제약 + 컬럼 드롭 (사전/사후 검증 쿼리 포함) |
| `room_collection_service.py` | `room_data`에서 `recommend_capacity` 키 제거 |
| 테스트 5개 | `== 값` assertion → `not in` 검증, dead fixture key 정리 |

## 배포 순서

> **반드시 코드 배포 → 마이그레이션 실행 순서**
>
> 코드가 먼저 배포되어야 `recommend_capacity` 키 없이 INSERT가 동작.
> 마이그레이션 먼저 실행하면 기존 코드에서 INSERT 실패.

## Test plan

- [x] 전체 테스트 432 passed, 4 skipped
- [ ] 마이그레이션 사전 검증 쿼리 실행 (recommend_capacity 분포 확인)
- [ ] 스테이징 환경에서 마이그레이션 실행 후 사후 검증 쿼리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed legacy single-value room recommendation; capacity guidance now provided exclusively as a recommendation range.
  * Database schema updated to drop the obsolete recommendation column and related constraint.
  * Test suite refreshed to align with the updated capacity data shape and preserve existing validations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->