### PR TITLE
[#275]; refactor: DreamCrawler 세마포어를 클래스 레벨로 이동

### DIFF
--- a/app/crawler/dream_checker.py
+++ b/app/crawler/dream_checker.py
@@ -29,6 +29,7 @@ class DreamCrawler(BaseCrawler):
         - 최대 예약 가능 일자(121일) 제한을 걸어, 서버 부하와 불필요한 크롤링을 방지.
     """
     _URL = "https://www.xn--hy1bm6g6ujjkgomr.com/plugin/wz.bookingT1.prm/ajax.calendar.time.php"
+    _semaphore: asyncio.Semaphore = asyncio.Semaphore(15)
     HEADERS = {
         "User-Agent": "Mozilla/5.0",
         "Content-Type": "application/x-www-form-urlencoded"
@@ -78,9 +79,6 @@ class DreamCrawler(BaseCrawler):
                 for room in target_rooms
             ]
 
-        # 드림합주실 서버 부하 방지를 위해 동시 요청 수를 15개로 제한
-        semaphore = asyncio.Semaphore(15)
-
         async def safe_fetch(room: RoomDetail) -> RoomResult:
             """개별 방 조회를 예외-안전하게 감싸 실패 시 Exception 객체를 반환한다.
 
@@ -90,7 +88,7 @@ class DreamCrawler(BaseCrawler):
             Returns:
                 RoomResult: 성공 시 RoomAvailability, 실패 시 Exception 객체.
             """
-            async with semaphore:
+            async with self._semaphore:
                 try:
                     return await self._fetch_dream_availability_room(date, hour_slots, room)
                 except BaseCustomException as e:

--- a/app/crawler/dream_checker.py
+++ b/app/crawler/dream_checker.py
@@ -1,3 +1,4 @@
+import os
 import html
 import asyncio
 import logging
@@ -29,7 +30,9 @@ class DreamCrawler(BaseCrawler):
         - 최대 예약 가능 일자(121일) 제한을 걸어, 서버 부하와 불필요한 크롤링을 방지.
     """
     _URL = "https://www.xn--hy1bm6g6ujjkgomr.com/plugin/wz.bookingT1.prm/ajax.calendar.time.php"
-    _semaphore: asyncio.Semaphore = asyncio.Semaphore(15)
+    # 드림합주실 서버 부하 방지: 동시 API 요청 수를 클래스 수준에서 공유하여 전역 동시성을 제한한다.
+    # check_availability 호출마다 새 세마포어를 만들면 호출 간 공유가 되지 않으므로 클래스 속성으로 초기화한다.
+    _semaphore: asyncio.Semaphore = asyncio.Semaphore(int(os.getenv("DREAM_CRAWLER_SEMAPHORE", "15")))
     HEADERS = {
         "User-Agent": "Mozilla/5.0",
         "Content-Type": "application/x-www-form-urlencoded"


### PR DESCRIPTION
closes #275 
## Summary
  - `check_availability` 호출마다 새 `asyncio.Semaphore(15)`를 생성하던 방식 제거
  - 클래스 레벨 `_semaphore: asyncio.Semaphore = asyncio.Semaphore(15)` 로 이동
  - `NaverCrawler`의 `_semaphore` 설계와 일관성 통일

  ## 문제
  동시 요청이 N개 들어올 경우 `15 × N`개의 동시 요청이 Dream 서버로 전송될 수 있었음.

  ## 수정
  클래스 레벨 세마포어로 서버 전체에서 최대 15개 동시 요청으로 제한.

  ## Test plan
  - [ ] `DreamCrawler.check_availability` 동시 호출 시 세마포어가 클래스 전체에서 공유되는지 확인        
  - [ ] 기존 단일 요청 플로우 정상 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized concurrency management for availability checks to ensure consistent and stable request handling across instances.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/summitBandWeb/pick-habju-backend/pull/283)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->