### PR TITLE
[#278] feat: 크롤러 프리페치 전용 세마포어 분리

### DIFF
--- a/app/crawler/base.py
+++ b/app/crawler/base.py
@@ -22,7 +22,7 @@ class BaseCrawler(ABC):
         registry.register("new", NewCrawler())
     """
     @abstractmethod
-    async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail]) -> List[RoomResult]:
+    async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail], *, prefetch: bool = False) -> List[RoomResult]:
         """
         주어진 날짜와 시간대에 대한 방 예약 가능 여부를 확인.
         

--- a/app/crawler/base.py
+++ b/app/crawler/base.py
@@ -30,7 +30,8 @@ class BaseCrawler(ABC):
             date: 조회할 날짜 (YYYY-MM-DD 형식)
             hour_slots: 조회할 시간대 리스트 (예: ["18:00", "19:00"])
             target_rooms: 조회할 방 정보 리스트
-            
+            prefetch: True이면 프리페치 전용 세마포어를 사용한다. 기본값 False(재검색).
+
         Returns:
             RoomAvailability 또는 Exception 리스트
             - 성공 시: RoomAvailability 객체 반환

--- a/app/crawler/dream_checker.py
+++ b/app/crawler/dream_checker.py
@@ -33,6 +33,8 @@ class DreamCrawler(BaseCrawler):
     # 드림합주실 서버 부하 방지: 동시 API 요청 수를 클래스 수준에서 공유하여 전역 동시성을 제한한다.
     # check_availability 호출마다 새 세마포어를 만들면 호출 간 공유가 되지 않으므로 클래스 속성으로 초기화한다.
     _semaphore: asyncio.Semaphore = asyncio.Semaphore(max(1, int(os.getenv("DREAM_CRAWLER_SEMAPHORE", "15"))))
+    # 프리페치 전용 세마포어: _semaphore와 슬롯을 공유하지 않아 프리페치가 재검색을 블로킹하지 않는다.
+    _prefetch_semaphore: asyncio.Semaphore = asyncio.Semaphore(max(1, int(os.getenv("DREAM_PREFETCH_SEMAPHORE", "15"))))
     HEADERS = {
         "User-Agent": "Mozilla/5.0",
         "Content-Type": "application/x-www-form-urlencoded"
@@ -50,7 +52,7 @@ class DreamCrawler(BaseCrawler):
         """
         return f"{int(hour_slot.split(':')[0]):02d}시00분"
 
-    async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail]) -> List[RoomResult]:
+    async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail], *, prefetch: bool = False) -> List[RoomResult]:
         """드림 합주실의 특정 날짜와 시간대에 예약 가능한 방들을 조회합니다.
 
         Args:
@@ -91,7 +93,8 @@ class DreamCrawler(BaseCrawler):
             Returns:
                 RoomResult: 성공 시 RoomAvailability, 실패 시 Exception 객체.
             """
-            async with self._semaphore:
+            sem = self._prefetch_semaphore if prefetch else self._semaphore
+            async with sem:
                 try:
                     return await self._fetch_dream_availability_room(date, hour_slots, room)
                 except BaseCustomException as e:

--- a/app/crawler/dream_checker.py
+++ b/app/crawler/dream_checker.py
@@ -59,6 +59,8 @@ class DreamCrawler(BaseCrawler):
             date (str): 조회할 날짜 (예: '2026-05-20')
             hour_slots (List[str]): 1시간 단위 시간 슬롯 배열 (예: ['14:00', '15:00'])
             target_rooms (List[RoomDetail]): 합주실 방 정보 리스트 (용량/지점 필터링이 완료된 상태)
+            prefetch (bool): True이면 _prefetch_semaphore를, False(기본값)이면 _semaphore를 사용한다.
+                프리페치 요청이 재검색 요청을 블로킹하지 않도록 세마포어를 분리한다.
 
         Returns:
             List[RoomResult]: 방별 예약 가능 여부(RoomAvailability) 또는 에러(Exception) 객체 배열

--- a/app/crawler/groove_checker.py
+++ b/app/crawler/groove_checker.py
@@ -22,9 +22,11 @@ class GrooveCrawler(BaseCrawler):
     """
 
     RESERVATION_LIMIT_DAYS = 84  # Reservation window limit per Groove policy.
-    _semaphore: asyncio.Semaphore = asyncio.Semaphore(int(os.getenv("GROOVE_CRAWLER_SEMAPHORE", "10")))
+    # NOTE: Naver/Dream과 달리 세마포어 적용 단위가 방(Room)이 아닌 로그인+HTML 패치 호출(배치 전체)임.
+    #       Groove는 단일 HTML 응답으로 모든 방을 파싱하는 구조이기 때문.
+    _semaphore: asyncio.Semaphore = asyncio.Semaphore(max(1, int(os.getenv("GROOVE_CRAWLER_SEMAPHORE", "10"))))
     # 프리페치 전용 세마포어: _semaphore와 슬롯을 공유하지 않아 프리페치가 재검색을 블로킹하지 않는다.
-    _prefetch_semaphore: asyncio.Semaphore = asyncio.Semaphore(int(os.getenv("GROOVE_PREFETCH_SEMAPHORE", "10")))
+    _prefetch_semaphore: asyncio.Semaphore = asyncio.Semaphore(max(1, int(os.getenv("GROOVE_PREFETCH_SEMAPHORE", "10"))))
 
     async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail], *, prefetch: bool = False) -> List[RoomResult]:
         """그루브 합주실의 특정 날짜와 시간대에 예약 가능한 방들을 조회한다.
@@ -36,6 +38,8 @@ class GrooveCrawler(BaseCrawler):
             date (str): 조회할 날짜 (예: '2026-05-20').
             hour_slots (List[str]): 1시간 단위 시간 슬롯 배열 (예: ['14:00', '15:00']).
             target_rooms (List[RoomDetail]): 조회 대상 방 리스트.
+            prefetch (bool): True이면 _prefetch_semaphore를, False(기본값)이면 _semaphore를 사용한다.
+                세마포어는 _login_and_fetch_html 호출(배치 전체) 단위로 획득한다.
 
         Returns:
             List[RoomResult]: 방별 RoomAvailability 또는 에러 Exception 객체 배열.

--- a/app/crawler/groove_checker.py
+++ b/app/crawler/groove_checker.py
@@ -1,8 +1,10 @@
-from typing import List
-from bs4 import BeautifulSoup
-import httpx
 import asyncio
+import os
 from datetime import datetime
+from typing import List
+
+import httpx
+from bs4 import BeautifulSoup
 
 from app.core.config import GROOVE_RESERVE_URL, GROOVE_RESERVE_URL1
 from app.exception.crawler.groove_exception import GrooveCredentialError, GrooveLoginError
@@ -20,8 +22,11 @@ class GrooveCrawler(BaseCrawler):
     """
 
     RESERVATION_LIMIT_DAYS = 84  # Reservation window limit per Groove policy.
+    _semaphore: asyncio.Semaphore = asyncio.Semaphore(int(os.getenv("GROOVE_CRAWLER_SEMAPHORE", "10")))
+    # 프리페치 전용 세마포어: _semaphore와 슬롯을 공유하지 않아 프리페치가 재검색을 블로킹하지 않는다.
+    _prefetch_semaphore: asyncio.Semaphore = asyncio.Semaphore(int(os.getenv("GROOVE_PREFETCH_SEMAPHORE", "10")))
 
-    async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail]) -> List[RoomResult]:
+    async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail], *, prefetch: bool = False) -> List[RoomResult]:
         """그루브 합주실의 특정 날짜와 시간대에 예약 가능한 방들을 조회한다.
 
         로그인 후 예약 페이지 HTML을 가져와 각 방의 슬롯 상태를 파싱한다.
@@ -54,8 +59,10 @@ class GrooveCrawler(BaseCrawler):
             ]
 
         # 3. 날짜가 유효한 범위 내에 있으면 데이터 가져오기 진행
+        sem = self._prefetch_semaphore if prefetch else self._semaphore
         try:
-            html = await self._login_and_fetch_html(date, branch_gubun="sadang")
+            async with sem:
+                html = await self._login_and_fetch_html(date, branch_gubun="sadang")
             soup = BeautifulSoup(html, "html.parser")
             tasks = [self._fetch_room_availability(room, hour_slots, soup) for room in target_rooms]
             results = await asyncio.gather(*tasks)

--- a/app/crawler/naver_checker.py
+++ b/app/crawler/naver_checker.py
@@ -23,8 +23,10 @@ class NaverCrawler(BaseCrawler):
     # check_availability 호출마다 새 세마포어를 만들면 호출 간 공유가 되지 않으므로 클래스 속성으로 초기화한다.
     # 높은 부하의 경우 환경 변수(NAVER_CRAWLER_SEMAPHORE)를 통해 조정 가능하도록 지원.
     _semaphore: asyncio.Semaphore = asyncio.Semaphore(int(os.getenv("NAVER_CRAWLER_SEMAPHORE", "30")))
+    # 프리페치 전용 세마포어: _semaphore와 슬롯을 공유하지 않아 프리페치가 재검색을 블로킹하지 않는다.
+    _prefetch_semaphore: asyncio.Semaphore = asyncio.Semaphore(int(os.getenv("NAVER_PREFETCH_SEMAPHORE", "30")))
 
-    async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail]) -> List[RoomResult]:
+    async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail], *, prefetch: bool = False) -> List[RoomResult]:
         """네이버 예약 API로 특정 날짜와 시간대에 예약 가능한 방들을 조회한다.
 
         각 방을 asyncio.gather로 병렬 조회하며, 개별 실패는 Exception 객체로
@@ -48,7 +50,8 @@ class NaverCrawler(BaseCrawler):
             Returns:
                 RoomResult: 성공 시 RoomAvailability, 실패 시 Exception 객체.
             """
-            async with self._semaphore:
+            sem = self._prefetch_semaphore if prefetch else self._semaphore
+            async with sem:
                 try:
                     return await self._fetch_naver_availability_room(date, hour_slots, room)
                 except BaseCustomException as e:

--- a/app/crawler/naver_checker.py
+++ b/app/crawler/naver_checker.py
@@ -22,9 +22,9 @@ class NaverCrawler(BaseCrawler):
     # 네이버 RATE LIMIT 대응: 동시 API 요청 수를 클래스 수준에서 공유하여 전역 동시성을 제한한다.
     # check_availability 호출마다 새 세마포어를 만들면 호출 간 공유가 되지 않으므로 클래스 속성으로 초기화한다.
     # 높은 부하의 경우 환경 변수(NAVER_CRAWLER_SEMAPHORE)를 통해 조정 가능하도록 지원.
-    _semaphore: asyncio.Semaphore = asyncio.Semaphore(int(os.getenv("NAVER_CRAWLER_SEMAPHORE", "30")))
+    _semaphore: asyncio.Semaphore = asyncio.Semaphore(max(1, int(os.getenv("NAVER_CRAWLER_SEMAPHORE", "30"))))
     # 프리페치 전용 세마포어: _semaphore와 슬롯을 공유하지 않아 프리페치가 재검색을 블로킹하지 않는다.
-    _prefetch_semaphore: asyncio.Semaphore = asyncio.Semaphore(int(os.getenv("NAVER_PREFETCH_SEMAPHORE", "30")))
+    _prefetch_semaphore: asyncio.Semaphore = asyncio.Semaphore(max(1, int(os.getenv("NAVER_PREFETCH_SEMAPHORE", "30"))))
 
     async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail], *, prefetch: bool = False) -> List[RoomResult]:
         """네이버 예약 API로 특정 날짜와 시간대에 예약 가능한 방들을 조회한다.
@@ -36,6 +36,8 @@ class NaverCrawler(BaseCrawler):
             date (str): 조회할 날짜 (예: '2026-05-20').
             hour_slots (List[str]): 1시간 단위 시간 슬롯 배열 (예: ['14:00', '15:00']).
             target_rooms (List[RoomDetail]): 조회 대상 방 리스트.
+            prefetch (bool): True이면 _prefetch_semaphore를, False(기본값)이면 _semaphore를 사용한다.
+                프리페치 요청이 재검색 요청을 블로킹하지 않도록 세마포어를 분리한다.
 
         Returns:
             List[RoomResult]: 방별 RoomAvailability 또는 에러 Exception 객체 배열.

--- a/tests/crawler/test_prefetch_semaphore.py
+++ b/tests/crawler/test_prefetch_semaphore.py
@@ -1,0 +1,221 @@
+"""
+크롤러 프리페치 세마포어 분리 검증 (#278)
+
+세 크롤러(Naver, Dream, Groove) 모두:
+- prefetch=False → _semaphore 사용
+- prefetch=True  → _prefetch_semaphore 사용
+- _prefetch_semaphore 포화 상태에서도 prefetch=False 요청은 블로킹 없이 진행
+"""
+import asyncio
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.crawler.naver_checker import NaverCrawler
+from app.crawler.dream_checker import DreamCrawler
+from app.crawler.groove_checker import GrooveCrawler
+from app.models.dto import RoomDetail
+
+
+FUTURE_DATE = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+HOUR_SLOTS = ["15:00"]
+
+
+# ---------------------------------------------------------------------------
+# 공용 픽스처 / 헬퍼
+# ---------------------------------------------------------------------------
+
+class _TrackedSemaphore:
+    """어떤 세마포어가 실제로 acquire됐는지 추적하는 가짜 세마포어."""
+    def __init__(self):
+        self.acquired = False
+
+    async def __aenter__(self):
+        self.acquired = True
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+@pytest.fixture
+def naver_room():
+    return RoomDetail(
+        name="테스트룸", branch="테스트 지점", business_id="123456", biz_item_id="999",
+        imageUrls=[], maxCapacity=6, recommend_capacity_range=[2, 4],
+        pricePerHour=15000, canReserveOneHour=True, requiresContactOnSameDay=False,
+    )
+
+
+@pytest.fixture
+def dream_room():
+    return RoomDetail(
+        name="드림 1룸", branch="드림합주실 사당점", business_id="dream_sadang", biz_item_id="1",
+        imageUrls=[], maxCapacity=6, recommend_capacity_range=[2, 4],
+        pricePerHour=15000, canReserveOneHour=True, requiresContactOnSameDay=False,
+    )
+
+
+@pytest.fixture
+def groove_room():
+    return RoomDetail(
+        name="A룸", branch="그루브 사당점", business_id="groove_sadang", biz_item_id="13",
+        imageUrls=[], maxCapacity=6, recommend_capacity_range=[2, 4],
+        pricePerHour=15000, canReserveOneHour=True, requiresContactOnSameDay=False,
+    )
+
+
+def _naver_mock_response():
+    resp = MagicMock()
+    resp.json.return_value = {"data": {"schedule": {"bizItemSchedule": {"hourly": []}}}}
+    return resp
+
+
+def _dream_mock_response():
+    resp = MagicMock()
+    resp.json.return_value = {"items": ""}
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# NaverCrawler
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_naver_normal_uses_semaphore(naver_room):
+    """prefetch=False 시 NaverCrawler가 _semaphore를 사용한다."""
+    normal_sem = _TrackedSemaphore()
+    prefetch_sem = _TrackedSemaphore()
+
+    with patch.object(NaverCrawler, "_semaphore", normal_sem), \
+         patch.object(NaverCrawler, "_prefetch_semaphore", prefetch_sem), \
+         patch("app.crawler.naver_checker.load_client", new_callable=AsyncMock, return_value=_naver_mock_response()):
+        await NaverCrawler().check_availability(FUTURE_DATE, HOUR_SLOTS, [naver_room], prefetch=False)
+
+    assert normal_sem.acquired is True
+    assert prefetch_sem.acquired is False
+
+
+@pytest.mark.asyncio
+async def test_naver_prefetch_uses_prefetch_semaphore(naver_room):
+    """prefetch=True 시 NaverCrawler가 _prefetch_semaphore를 사용한다."""
+    normal_sem = _TrackedSemaphore()
+    prefetch_sem = _TrackedSemaphore()
+
+    with patch.object(NaverCrawler, "_semaphore", normal_sem), \
+         patch.object(NaverCrawler, "_prefetch_semaphore", prefetch_sem), \
+         patch("app.crawler.naver_checker.load_client", new_callable=AsyncMock, return_value=_naver_mock_response()):
+        await NaverCrawler().check_availability(FUTURE_DATE, HOUR_SLOTS, [naver_room], prefetch=True)
+
+    assert prefetch_sem.acquired is True
+    assert normal_sem.acquired is False
+
+
+@pytest.mark.asyncio
+async def test_naver_normal_not_blocked_by_full_prefetch_semaphore(naver_room):
+    """_prefetch_semaphore가 포화 상태(슬롯=0)여도 prefetch=False 요청은 블로킹 없이 완료된다."""
+    with patch.object(NaverCrawler, "_prefetch_semaphore", asyncio.Semaphore(0)), \
+         patch("app.crawler.naver_checker.load_client", new_callable=AsyncMock, return_value=_naver_mock_response()):
+        result = await asyncio.wait_for(
+            NaverCrawler().check_availability(FUTURE_DATE, HOUR_SLOTS, [naver_room], prefetch=False),
+            timeout=1.0,
+        )
+    assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# DreamCrawler
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_dream_normal_uses_semaphore(dream_room):
+    """prefetch=False 시 DreamCrawler가 _semaphore를 사용한다."""
+    normal_sem = _TrackedSemaphore()
+    prefetch_sem = _TrackedSemaphore()
+
+    with patch.object(DreamCrawler, "_semaphore", normal_sem), \
+         patch.object(DreamCrawler, "_prefetch_semaphore", prefetch_sem), \
+         patch("app.crawler.dream_checker.load_client", new_callable=AsyncMock, return_value=_dream_mock_response()):
+        await DreamCrawler().check_availability(FUTURE_DATE, HOUR_SLOTS, [dream_room], prefetch=False)
+
+    assert normal_sem.acquired is True
+    assert prefetch_sem.acquired is False
+
+
+@pytest.mark.asyncio
+async def test_dream_prefetch_uses_prefetch_semaphore(dream_room):
+    """prefetch=True 시 DreamCrawler가 _prefetch_semaphore를 사용한다."""
+    normal_sem = _TrackedSemaphore()
+    prefetch_sem = _TrackedSemaphore()
+
+    with patch.object(DreamCrawler, "_semaphore", normal_sem), \
+         patch.object(DreamCrawler, "_prefetch_semaphore", prefetch_sem), \
+         patch("app.crawler.dream_checker.load_client", new_callable=AsyncMock, return_value=_dream_mock_response()):
+        await DreamCrawler().check_availability(FUTURE_DATE, HOUR_SLOTS, [dream_room], prefetch=True)
+
+    assert prefetch_sem.acquired is True
+    assert normal_sem.acquired is False
+
+
+@pytest.mark.asyncio
+async def test_dream_normal_not_blocked_by_full_prefetch_semaphore(dream_room):
+    """_prefetch_semaphore가 포화 상태(슬롯=0)여도 prefetch=False 요청은 블로킹 없이 완료된다."""
+    with patch.object(DreamCrawler, "_prefetch_semaphore", asyncio.Semaphore(0)), \
+         patch("app.crawler.dream_checker.load_client", new_callable=AsyncMock, return_value=_dream_mock_response()):
+        result = await asyncio.wait_for(
+            DreamCrawler().check_availability(FUTURE_DATE, HOUR_SLOTS, [dream_room], prefetch=False),
+            timeout=1.0,
+        )
+    assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# GrooveCrawler
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def groove_mock_html(groove_room):
+    biz_item_id = groove_room.biz_item_id
+    return f'<div id="reserve_time_{biz_item_id}_15" class="reserve_time_off"></div>'
+
+
+@pytest.mark.asyncio
+async def test_groove_normal_uses_semaphore(groove_room, groove_mock_html):
+    """prefetch=False 시 GrooveCrawler가 _semaphore를 사용한다."""
+    normal_sem = _TrackedSemaphore()
+    prefetch_sem = _TrackedSemaphore()
+
+    with patch.object(GrooveCrawler, "_semaphore", normal_sem), \
+         patch.object(GrooveCrawler, "_prefetch_semaphore", prefetch_sem), \
+         patch.object(GrooveCrawler, "_login_and_fetch_html", new_callable=AsyncMock, return_value=groove_mock_html):
+        await GrooveCrawler().check_availability(FUTURE_DATE, HOUR_SLOTS, [groove_room], prefetch=False)
+
+    assert normal_sem.acquired is True
+    assert prefetch_sem.acquired is False
+
+
+@pytest.mark.asyncio
+async def test_groove_prefetch_uses_prefetch_semaphore(groove_room, groove_mock_html):
+    """prefetch=True 시 GrooveCrawler가 _prefetch_semaphore를 사용한다."""
+    normal_sem = _TrackedSemaphore()
+    prefetch_sem = _TrackedSemaphore()
+
+    with patch.object(GrooveCrawler, "_semaphore", normal_sem), \
+         patch.object(GrooveCrawler, "_prefetch_semaphore", prefetch_sem), \
+         patch.object(GrooveCrawler, "_login_and_fetch_html", new_callable=AsyncMock, return_value=groove_mock_html):
+        await GrooveCrawler().check_availability(FUTURE_DATE, HOUR_SLOTS, [groove_room], prefetch=True)
+
+    assert prefetch_sem.acquired is True
+    assert normal_sem.acquired is False
+
+
+@pytest.mark.asyncio
+async def test_groove_normal_not_blocked_by_full_prefetch_semaphore(groove_room, groove_mock_html):
+    """_prefetch_semaphore가 포화 상태(슬롯=0)여도 prefetch=False 요청은 블로킹 없이 완료된다."""
+    with patch.object(GrooveCrawler, "_prefetch_semaphore", asyncio.Semaphore(0)), \
+         patch.object(GrooveCrawler, "_login_and_fetch_html", new_callable=AsyncMock, return_value=groove_mock_html):
+        result = await asyncio.wait_for(
+            GrooveCrawler().check_availability(FUTURE_DATE, HOUR_SLOTS, [groove_room], prefetch=False),
+            timeout=1.0,
+        )
+    assert isinstance(result, list)

--- a/tests/crawler/test_prefetch_semaphore.py
+++ b/tests/crawler/test_prefetch_semaphore.py
@@ -27,19 +27,23 @@ HOUR_SLOTS = ["15:00"]
 
 class _TrackedSemaphore:
     """어떤 세마포어가 실제로 acquire됐는지 추적하는 가짜 세마포어."""
+
     def __init__(self):
+        """acquired 플래그를 False로 초기화한다."""
         self.acquired = False
 
     async def __aenter__(self):
+        """컨텍스트 진입 시 acquired를 True로 설정한다."""
         self.acquired = True
         return self
 
     async def __aexit__(self, *args):
-        pass
+        """컨텍스트 종료 시 아무 작업도 하지 않는다."""
 
 
 @pytest.fixture
 def naver_room():
+    """네이버 크롤러 테스트용 RoomDetail 픽스처."""
     return RoomDetail(
         name="테스트룸", branch="테스트 지점", business_id="123456", biz_item_id="999",
         imageUrls=[], maxCapacity=6, recommend_capacity_range=[2, 4],
@@ -49,6 +53,7 @@ def naver_room():
 
 @pytest.fixture
 def dream_room():
+    """드림 크롤러 테스트용 RoomDetail 픽스처."""
     return RoomDetail(
         name="드림 1룸", branch="드림합주실 사당점", business_id="dream_sadang", biz_item_id="1",
         imageUrls=[], maxCapacity=6, recommend_capacity_range=[2, 4],
@@ -58,6 +63,7 @@ def dream_room():
 
 @pytest.fixture
 def groove_room():
+    """그루브 크롤러 테스트용 RoomDetail 픽스처."""
     return RoomDetail(
         name="A룸", branch="그루브 사당점", business_id="groove_sadang", biz_item_id="13",
         imageUrls=[], maxCapacity=6, recommend_capacity_range=[2, 4],
@@ -66,12 +72,14 @@ def groove_room():
 
 
 def _naver_mock_response():
+    """빈 hourly 슬롯을 반환하는 네이버 API 모의 응답을 생성한다."""
     resp = MagicMock()
     resp.json.return_value = {"data": {"schedule": {"bizItemSchedule": {"hourly": []}}}}
     return resp
 
 
 def _dream_mock_response():
+    """빈 items HTML을 반환하는 드림 API 모의 응답을 생성한다."""
     resp = MagicMock()
     resp.json.return_value = {"items": ""}
     return resp
@@ -175,6 +183,7 @@ async def test_dream_normal_not_blocked_by_full_prefetch_semaphore(dream_room):
 
 @pytest.fixture
 def groove_mock_html(groove_room):
+    """그루브 예약 페이지 HTML 모의 데이터 픽스처."""
     biz_item_id = groove_room.biz_item_id
     return f'<div id="reserve_time_{biz_item_id}_15" class="reserve_time_off"></div>'
 


### PR DESCRIPTION
closes #278 

## Summary

- 프리페치 아키텍처 도입 시 재검색이 프리페치 크롤링에 블로킹되지 않도록 세마포어 분리
- `BaseCrawler.check_availability`에 `prefetch: bool = False` 키워드 파라미터 추가
- 기존 호출부(`availability_service.py`)는 변경 없이 `prefetch=False` 기본값 사용

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `app/crawler/base.py` | `check_availability` 시그니처에 `*, prefetch: bool = False` 추가 |
| `app/crawler/naver_checker.py` | `_prefetch_semaphore`(`NAVER_PREFETCH_SEMAPHORE`, 기본 30) 추가 |
| `app/crawler/dream_checker.py` | `_prefetch_semaphore`(`DREAM_PREFETCH_SEMAPHORE`, 기본 15) 추가 |
| `app/crawler/groove_checker.py` | `_semaphore`(`GROOVE_CRAWLER_SEMAPHORE`, 기본 10) + `_prefetch_semaphore`(`GROOVE_PREFETCH_SEMAPHORE`, 기본 10) 추가 |
| `tests/crawler/test_prefetch_semaphore.py` | 세 크롤러 × 3시나리오 총 9개 테스트 신설 |

## 동시 요청 현황 (Naver 기준)

| 상황 | 사용 세마포어 | 최대 동시 요청 |
|---|---|---|
| 재검색(~5룸) | `_semaphore` | 5 |
| 프리페치 | `_prefetch_semaphore` | 30 |
| 둘 동시 | 각자 독립 | 35 |

## Test plan

- [x] `prefetch=False` → `_semaphore` 사용 검증 (Naver, Dream, Groove)
- [x] `prefetch=True` → `_prefetch_semaphore` 사용 검증 (Naver, Dream, Groove)
- [x] `_prefetch_semaphore` 포화(슬롯=0) 시 `prefetch=False` 요청 블로킹 없이 완료 검증
- [x] 기존 크롤러 테스트 회귀 없음 (7 passed, 1 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prefetch capability to room availability crawlers for improved request handling across crawler implementations.

* **Tests**
  * Added comprehensive test coverage for prefetch operations to ensure proper concurrency behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/summitBandWeb/pick-habju-backend/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->