### PR TITLE
[#279]; feat: prefetch_all 구현 및 BackgroundTasks 연동

### DIFF
--- a/app/api/available_room.py
+++ b/app/api/available_room.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from fastapi.exceptions import RequestValidationError
 from typing import Optional
 from pydantic import ValidationError
@@ -78,6 +78,7 @@ router = APIRouter(prefix="/api/rooms/availability", tags=["예약 가능 여부
 @limiter.limit(f"{RATE_LIMIT_PER_MINUTE}/minute")  # Rate Limit 적용
 async def check_room_availability(
     request: Request,  # noqa: ARG001
+    background_tasks: BackgroundTasks,
     date: str = Query(..., description="날짜 (YYYY-MM-DD)"),
     capacity: int = Query(..., description="사용 인원 수", json_schema_extra={"example": 10}),
     start_hour: str = Query(..., description="시작 시간 (HH:MM)", json_schema_extra={"example": "14:00"}),
@@ -126,4 +127,5 @@ async def check_room_availability(
         raise RequestValidationError(e.errors()) from e
 
     result = await service.check_availability(request=svc_request)
+    background_tasks.add_task(service.prefetch_all, svc_request)
     return ApiResponse.success(result=result)

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -93,6 +93,8 @@ class AvailabilityService:
 
     # get_availability_service 의존성이 요청마다 새 인스턴스를 생성하므로,
     # 중복 실행 방지를 위한 in-flight set은 클래스 레벨에서 공유해야 한다.
+    # NOTE: 단일 프로세스(워커) 환경에서만 중복 방지 보장.
+    #       멀티 워커 배포 시 Redis 기반 분산 락으로 교체 필요.
     _prefetch_in_flight: set = set()
 
     def __init__(self, crawlers_map: dict[str, BaseCrawler]):
@@ -300,7 +302,11 @@ class AvailabilityService:
         다음 사용자 요청 시 캐시에서 즉시 응답할 수 있도록 준비한다.
 
         Args:
-            request: 원본 검색 요청. date/start_hour/end_hour을 공유 캐시 키로 사용한다.
+            request: 원본 검색 요청.
+
+        Note:
+            request의 date, start_hour, end_hour만 사용한다.
+            capacity, swLat 등 뷰포트 필드는 무시되며, 서비스 지역 전체 룸(capacity=1)을 대상으로 한다.
 
         Rationale:
             _prefetch_in_flight set으로 동일 (date, start_hour, end_hour) 조합에 대한
@@ -387,6 +393,11 @@ class AvailabilityService:
                         if existing.available != item.available:
                             existing.available = False
                         existing.available_slots.update(item.available_slots)
+                        # overnight 분할 결과 가격 누산 (check_availability 병합 로직과 동일)
+                        if isinstance(existing.estimated_price, int) and isinstance(item.estimated_price, int):
+                            existing.estimated_price += item.estimated_price
+                        elif isinstance(item.estimated_price, int):
+                            existing.estimated_price = item.estimated_price
                     else:
                         merge_temp[bid] = item
 

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -67,29 +67,33 @@ class FailedCrawl:
 
 class AvailabilityService:
     """합주실 예약 가능 여부 조회 서비스
-    
+
     여러 크롤러를 사용하여 동시에 예약 가능 여부를 조회하고,
     결과를 통합하여 반환합니다. 비즈니스 로직을 API 라우터에서 분리하여
     테스트 가능성과 재사용성을 높입니다.
-    
+
     비즈니스 맥락:
     - Dream, Groove, Naver 등 여러 플랫폼의 합주실을 통합 조회
     - 각 크롤러마다 다른 크롤링 기법을 사용하여 데이터 수집
     - 일부 크롤러 실패 시에도 성공한 결과 반환 (Graceful Degradation)
-    
+
     설계 결정:
     - Dependency Injection을 통해 크롤러 주입 (테스트 용이성 확보)
     - 비동기 병렬 처리로 응답 속도 최적화 (asyncio.gather 사용)
     - 에러를 Exception 객체로 반환하여 로깅 및 필터링
-    
+
     사용 예시:
         >>> crawlers_map = {"dream": DreamCrawler(), "groove": GrooveCrawler()}
         >>> service = AvailabilityService(crawlers_map)
         >>> response = await service.check_availability(request)
-    
+
     Attributes:
         crawlers_map (dict): 크롤러 타입을 키로, BaseCrawler 인스턴스를 값으로 하는 딕셔너리
     """
+
+    # get_availability_service 의존성이 요청마다 새 인스턴스를 생성하므로,
+    # 중복 실행 방지를 위한 in-flight set은 클래스 레벨에서 공유해야 한다.
+    _prefetch_in_flight: set = set()
 
     def __init__(self, crawlers_map: dict[str, BaseCrawler]):
         """서비스 초기화
@@ -100,7 +104,6 @@ class AvailabilityService:
         """
         self.crawlers_map = crawlers_map
         self.pricing_service = PricingService()
-        self._prefetch_in_flight: set = set()
 
     # 시작시간과 종료시간으로 시간 슬롯 리스트 생성
     def generate_time_slots(self, start_str: str, end_str: str) -> List[str]:
@@ -376,6 +379,7 @@ class AvailabilityService:
                     continue
                 for item in res_list:
                     if not isinstance(item, RoomAvailability):
+                        logger.debug(f"[prefetch_all] 룸 단위 크롤링 실패: {item}")
                         continue
                     bid = item.room_detail.biz_item_id
                     if bid in merge_temp:

--- a/app/services/availability_service.py
+++ b/app/services/availability_service.py
@@ -93,13 +93,14 @@ class AvailabilityService:
 
     def __init__(self, crawlers_map: dict[str, BaseCrawler]):
         """서비스 초기화
-        
+
         Args:
             crawlers_map: 플랫폼 타입을 키로 하고 BaseCrawler 인스턴스를 값으로 하는 매핑 딕셔너리
                          예: {"dream": DreamCrawler(), "groove": GrooveCrawler()}
         """
         self.crawlers_map = crawlers_map
         self.pricing_service = PricingService()
+        self._prefetch_in_flight: set = set()
 
     # 시작시간과 종료시간으로 시간 슬롯 리스트 생성
     def generate_time_slots(self, start_str: str, end_str: str) -> List[str]:
@@ -288,6 +289,116 @@ class AvailabilityService:
             and any(v is True for v in res.available_slots.values())
         )
         
+
+    async def prefetch_all(self, request: AvailabilityRequest) -> None:
+        """백그라운드 프리페치: 서비스 지역 내 전체 룸의 예약 가능 여부를 미리 조회하여 캐시에 채워넣는다.
+
+        check_availability API 응답 직후 BackgroundTasks로 실행되며,
+        다음 사용자 요청 시 캐시에서 즉시 응답할 수 있도록 준비한다.
+
+        Args:
+            request: 원본 검색 요청. date/start_hour/end_hour을 공유 캐시 키로 사용한다.
+
+        Rationale:
+            _prefetch_in_flight set으로 동일 (date, start_hour, end_hour) 조합에 대한
+            중복 실행을 방지한다. asyncio 단일 스레드 특성 덕분에 별도 Lock 없이 안전하다.
+        """
+        lock_key = (request.date, request.start_hour, request.end_hour)
+        if lock_key in self._prefetch_in_flight:
+            logger.info(f"[prefetch_all] 이미 진행 중, 스킵: {lock_key}")
+            return
+        self._prefetch_in_flight.add(lock_key)
+
+        try:
+            # 1. 서비스 지역 내 전체 룸 조회 (capacity=1, 좌표 없음 → 서비스 지역 전체)
+            try:
+                all_rooms = await get_rooms_by_criteria(capacity=1)
+            except Exception as e:
+                logger.warning(f"[prefetch_all] DB 조회 실패, 조기 종료: {e}")
+                return
+
+            # 2. 이미 캐시 또는 inflight에 있는 룸 제외
+            target_rooms = [
+                room for room in all_rooms
+                if not availability_cache.is_pending(
+                    request.date, request.start_hour, request.end_hour, room.biz_item_id
+                )
+            ]
+
+            if not target_rooms:
+                logger.info(f"[prefetch_all] 프리페치 대상 없음 (전부 캐시/inflight): {lock_key}")
+                return
+
+            # 3. 시간 슬롯 생성
+            try:
+                hour_slots = self.generate_time_slots(request.start_hour, request.end_hour)
+            except ValueError as e:
+                logger.warning(f"[prefetch_all] 시간 슬롯 생성 실패: {e}")
+                return
+
+            slots_to_check = hour_slots[:-1]
+            start_mins = self._slot_to_minutes(request.start_hour)
+            end_min = self._slot_to_minutes(request.end_hour)
+            is_overnight = start_mins > end_min
+
+            if is_overnight:
+                day1_slots = [s for s in slots_to_check if self._slot_to_minutes(s) >= start_mins]
+                day2_slots = [s for s in slots_to_check if s not in day1_slots]
+                next_date = self._get_next_day_str(request.date)
+            else:
+                day1_slots = slots_to_check
+                day2_slots = []
+
+            # 4. 크롤러별 prefetch=True로 실행
+            tasks = []
+            for crawler_type, crawler in self.crawlers_map.items():
+                filtered = filter_rooms_by_type(target_rooms, crawler_type)
+                if not filtered:
+                    continue
+                if is_overnight:
+                    if day1_slots:
+                        tasks.append(crawler.check_availability(request.date, day1_slots, filtered, prefetch=True))
+                    if day2_slots:
+                        tasks.append(crawler.check_availability(next_date, day2_slots, filtered, prefetch=True))
+                else:
+                    tasks.append(crawler.check_availability(request.date, day1_slots, filtered, prefetch=True))
+
+            if not tasks:
+                return
+
+            results_of_lists = await asyncio.gather(*tasks, return_exceptions=True)
+
+            # 5. overnight 결과 병합 및 캐시 저장
+            merge_temp: Dict[str, RoomAvailability] = {}
+            for res_list in results_of_lists:
+                if isinstance(res_list, Exception):
+                    logger.warning(f"[prefetch_all] 크롤러 배치 실패: {res_list}")
+                    continue
+                for item in res_list:
+                    if not isinstance(item, RoomAvailability):
+                        continue
+                    bid = item.room_detail.biz_item_id
+                    if bid in merge_temp:
+                        existing = merge_temp[bid]
+                        if existing.available != item.available:
+                            existing.available = False
+                        existing.available_slots.update(item.available_slots)
+                    else:
+                        merge_temp[bid] = item
+
+            for bid, result in merge_temp.items():
+                availability_cache.set(
+                    request.date, request.start_hour, request.end_hour, bid, result
+                )
+
+            logger.info(
+                f"[prefetch_all] 완료: date={request.date} {request.start_hour}-{request.end_hour} | "
+                f"대상={len(target_rooms)}개 | 저장={len(merge_temp)}개"
+            )
+        except Exception as e:
+            logger.warning(f"[prefetch_all] 예상치 못한 오류: {e}")
+        finally:
+            self._prefetch_in_flight.discard(lock_key)
 
     async def check_availability(self, request: AvailabilityRequest) -> AvailabilityResponse:
         """조건에 맞는 합주실들의 예약 가능 여부를 일괄 조회합니다.

--- a/tests/services/test_prefetch_all.py
+++ b/tests/services/test_prefetch_all.py
@@ -21,10 +21,12 @@ FUTURE_DATE = (datetime.now() + timedelta(days=30)).strftime("%Y-%m-%d")
 
 @pytest.fixture(autouse=True)
 def clear_cache():
-    """각 테스트 전후로 캐시를 비워 테스트 간 오염을 방지한다."""
+    """각 테스트 전후로 캐시 및 클래스 레벨 in-flight set을 초기화하여 테스트 간 오염을 방지한다."""
     availability_cache.clear()
+    AvailabilityService._prefetch_in_flight.clear()
     yield
     availability_cache.clear()
+    AvailabilityService._prefetch_in_flight.clear()
 
 
 def _make_request(**kwargs) -> AvailabilityRequest:
@@ -37,10 +39,10 @@ def _make_request(**kwargs) -> AvailabilityRequest:
     return AvailabilityRequest(**defaults)
 
 
-def _make_room(biz_item_id: str = "r1") -> RoomDetail:
+def _make_room(biz_item_id: str = "r1", business_id: str = "b1") -> RoomDetail:
     """테스트용 RoomDetail 팩토리."""
     return RoomDetail(
-        name="TestRoom", branch="Branch", business_id="b1", biz_item_id=biz_item_id,
+        name="TestRoom", branch="Branch", business_id=business_id, biz_item_id=biz_item_id,
         pricePerHour=10000, max_capacity=10, can_reserve_one_hour=True,
         requiresContactOnSameDay=False, recommend_capacity_range=[2, 4],
     )
@@ -70,13 +72,12 @@ def service(mock_crawler):
 
 @pytest.mark.asyncio
 async def test_prefetch_all_skips_pending_rooms(service, mock_crawler):
-    """is_pending()이 True인 룸은 크롤러에 전달되지 않는다."""
+    """is_pending()이 True인 룸은 target_rooms에서 제외되어 크롤러가 호출되지 않는다."""
     room = _make_room("r1")
     availability_cache.set(FUTURE_DATE, "14:00", "16:00", "r1", _make_avail(room))
 
     req = _make_request()
-    with patch("app.services.availability_service.get_rooms_by_criteria", return_value=[room]), \
-         patch("app.services.availability_service.filter_rooms_by_type", return_value=[]):
+    with patch("app.services.availability_service.get_rooms_by_criteria", return_value=[room]):
         await service.prefetch_all(req)
 
     mock_crawler.check_availability.assert_not_called()
@@ -87,16 +88,13 @@ async def test_prefetch_all_prevents_duplicate_execution(service, mock_crawler):
     """_prefetch_in_flight에 동일 키가 있으면 두 번째 호출은 DB 조회 없이 즉시 반환된다."""
     req = _make_request()
     lock_key = (req.date, req.start_hour, req.end_hour)
-    service._prefetch_in_flight.add(lock_key)
+    AvailabilityService._prefetch_in_flight.add(lock_key)
 
-    try:
-        with patch("app.services.availability_service.get_rooms_by_criteria") as mock_db:
-            await service.prefetch_all(req)
+    with patch("app.services.availability_service.get_rooms_by_criteria") as mock_db:
+        await service.prefetch_all(req)
 
-        mock_db.assert_not_called()
-        mock_crawler.check_availability.assert_not_called()
-    finally:
-        service._prefetch_in_flight.discard(lock_key)
+    mock_db.assert_not_called()
+    mock_crawler.check_availability.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/services/test_prefetch_all.py
+++ b/tests/services/test_prefetch_all.py
@@ -1,0 +1,172 @@
+"""
+AvailabilityService.prefetch_all 단위 테스트 (#279)
+
+커버리지:
+- is_pending() True인 룸 스킵
+- _prefetch_in_flight 중복 실행 방지
+- DB 조회 실패 시 조기 종료 (크롤러 호출 없음)
+- 크롤링 성공 시 결과가 availability_cache에 저장됨
+- 개별 룸 예외가 다른 룸의 캐시 저장을 막지 않음
+"""
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.availability_service import AvailabilityService
+from app.models.dto import AvailabilityRequest, RoomAvailability, RoomDetail
+from app.utils.availability_cache import availability_cache
+
+FUTURE_DATE = (datetime.now() + timedelta(days=30)).strftime("%Y-%m-%d")
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """각 테스트 전후로 캐시를 비워 테스트 간 오염을 방지한다."""
+    availability_cache.clear()
+    yield
+    availability_cache.clear()
+
+
+def _make_request(**kwargs) -> AvailabilityRequest:
+    """기본값이 채워진 AvailabilityRequest 팩토리."""
+    defaults = dict(
+        date=FUTURE_DATE, capacity=2, start_hour="14:00", end_hour="16:00",
+        swLat=37.0, swLng=126.0, neLat=38.0, neLng=127.0,
+    )
+    defaults.update(kwargs)
+    return AvailabilityRequest(**defaults)
+
+
+def _make_room(biz_item_id: str = "r1") -> RoomDetail:
+    """테스트용 RoomDetail 팩토리."""
+    return RoomDetail(
+        name="TestRoom", branch="Branch", business_id="b1", biz_item_id=biz_item_id,
+        pricePerHour=10000, max_capacity=10, can_reserve_one_hour=True,
+        requiresContactOnSameDay=False, recommend_capacity_range=[2, 4],
+    )
+
+
+def _make_avail(room: RoomDetail) -> RoomAvailability:
+    """완전 예약 가능 RoomAvailability 팩토리."""
+    return RoomAvailability(
+        room_detail=room, available=True,
+        available_slots={"14:00": True, "15:00": True},
+    )
+
+
+@pytest.fixture
+def mock_crawler():
+    """AsyncMock check_availability를 가진 가짜 크롤러."""
+    crawler = MagicMock()
+    crawler.check_availability = AsyncMock()
+    return crawler
+
+
+@pytest.fixture
+def service(mock_crawler):
+    """naver 크롤러만 주입된 AvailabilityService."""
+    return AvailabilityService({"naver": mock_crawler})
+
+
+@pytest.mark.asyncio
+async def test_prefetch_all_skips_pending_rooms(service, mock_crawler):
+    """is_pending()이 True인 룸은 크롤러에 전달되지 않는다."""
+    room = _make_room("r1")
+    availability_cache.set(FUTURE_DATE, "14:00", "16:00", "r1", _make_avail(room))
+
+    req = _make_request()
+    with patch("app.services.availability_service.get_rooms_by_criteria", return_value=[room]), \
+         patch("app.services.availability_service.filter_rooms_by_type", return_value=[]):
+        await service.prefetch_all(req)
+
+    mock_crawler.check_availability.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_prefetch_all_prevents_duplicate_execution(service, mock_crawler):
+    """_prefetch_in_flight에 동일 키가 있으면 두 번째 호출은 DB 조회 없이 즉시 반환된다."""
+    req = _make_request()
+    lock_key = (req.date, req.start_hour, req.end_hour)
+    service._prefetch_in_flight.add(lock_key)
+
+    try:
+        with patch("app.services.availability_service.get_rooms_by_criteria") as mock_db:
+            await service.prefetch_all(req)
+
+        mock_db.assert_not_called()
+        mock_crawler.check_availability.assert_not_called()
+    finally:
+        service._prefetch_in_flight.discard(lock_key)
+
+
+@pytest.mark.asyncio
+async def test_prefetch_all_early_return_on_db_failure(service, mock_crawler):
+    """DB 조회 실패 시 크롤러를 호출하지 않고 조기 종료한다."""
+    req = _make_request()
+    with patch("app.services.availability_service.get_rooms_by_criteria", side_effect=Exception("DB 오류")):
+        await service.prefetch_all(req)
+
+    mock_crawler.check_availability.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_prefetch_all_stores_results_in_cache(service, mock_crawler):
+    """크롤링 성공 결과가 availability_cache에 저장된다."""
+    room = _make_room("r1")
+    avail = _make_avail(room)
+    mock_crawler.check_availability.return_value = [avail]
+
+    req = _make_request()
+    with patch("app.services.availability_service.get_rooms_by_criteria", return_value=[room]), \
+         patch("app.services.availability_service.filter_rooms_by_type", return_value=[room]):
+        await service.prefetch_all(req)
+
+    cached = availability_cache.get(FUTURE_DATE, "14:00", "16:00", "r1")
+    assert cached is not None
+    assert cached.available is True
+
+
+@pytest.mark.asyncio
+async def test_prefetch_all_individual_failure_does_not_block_others(service, mock_crawler):
+    """개별 룸 예외(Exception)가 다른 룸의 캐시 저장을 막지 않는다."""
+    room_ok = _make_room("r1")
+    room_fail = _make_room("r2")
+    avail_ok = _make_avail(room_ok)
+
+    mock_crawler.check_availability.return_value = [avail_ok, Exception("r2 크롤링 실패")]
+
+    req = _make_request()
+    with patch("app.services.availability_service.get_rooms_by_criteria", return_value=[room_ok, room_fail]), \
+         patch("app.services.availability_service.filter_rooms_by_type", return_value=[room_ok, room_fail]):
+        await service.prefetch_all(req)
+
+    assert availability_cache.get(FUTURE_DATE, "14:00", "16:00", "r1") is not None
+    assert availability_cache.get(FUTURE_DATE, "14:00", "16:00", "r2") is None
+
+
+@pytest.mark.asyncio
+async def test_prefetch_all_inflight_cleared_after_completion(service, mock_crawler):
+    """prefetch_all 완료 후 _prefetch_in_flight에서 키가 제거된다."""
+    room = _make_room("r1")
+    mock_crawler.check_availability.return_value = [_make_avail(room)]
+
+    req = _make_request()
+    lock_key = (req.date, req.start_hour, req.end_hour)
+
+    with patch("app.services.availability_service.get_rooms_by_criteria", return_value=[room]), \
+         patch("app.services.availability_service.filter_rooms_by_type", return_value=[room]):
+        await service.prefetch_all(req)
+
+    assert lock_key not in service._prefetch_in_flight
+
+
+@pytest.mark.asyncio
+async def test_prefetch_all_inflight_cleared_on_db_failure(service, mock_crawler):
+    """DB 실패로 조기 종료해도 _prefetch_in_flight에서 키가 제거된다."""
+    req = _make_request()
+    lock_key = (req.date, req.start_hour, req.end_hour)
+
+    with patch("app.services.availability_service.get_rooms_by_criteria", side_effect=Exception("DB 오류")):
+        await service.prefetch_all(req)
+
+    assert lock_key not in service._prefetch_in_flight

--- a/tests/services/test_prefetch_all.py
+++ b/tests/services/test_prefetch_all.py
@@ -155,7 +155,7 @@ async def test_prefetch_all_inflight_cleared_after_completion(service, mock_craw
          patch("app.services.availability_service.filter_rooms_by_type", return_value=[room]):
         await service.prefetch_all(req)
 
-    assert lock_key not in service._prefetch_in_flight
+    assert lock_key not in AvailabilityService._prefetch_in_flight
 
 
 @pytest.mark.asyncio
@@ -167,4 +167,33 @@ async def test_prefetch_all_inflight_cleared_on_db_failure(service, mock_crawler
     with patch("app.services.availability_service.get_rooms_by_criteria", side_effect=Exception("DB 오류")):
         await service.prefetch_all(req)
 
-    assert lock_key not in service._prefetch_in_flight
+    assert lock_key not in AvailabilityService._prefetch_in_flight
+
+
+@pytest.mark.asyncio
+async def test_prefetch_all_overnight_merges_day1_and_day2(service, mock_crawler):
+    """overnight(start > end) 요청 시 day1/day2 크롤러 결과가 병합되어 캐시에 저장된다."""
+    room = _make_room("r1")
+    day1_avail = RoomAvailability(
+        room_detail=room, available=True,
+        available_slots={"23:00": True},
+        estimated_price=10000,
+    )
+    day2_avail = RoomAvailability(
+        room_detail=room, available=True,
+        available_slots={"00:00": True, "01:00": True},
+        estimated_price=20000,
+    )
+    mock_crawler.check_availability.side_effect = [[day1_avail], [day2_avail]]
+
+    req = _make_request(start_hour="23:00", end_hour="02:00")
+    with patch("app.services.availability_service.get_rooms_by_criteria", return_value=[room]), \
+         patch("app.services.availability_service.filter_rooms_by_type", return_value=[room]):
+        await service.prefetch_all(req)
+
+    assert mock_crawler.check_availability.call_count == 2
+
+    cached = availability_cache.get(FUTURE_DATE, "23:00", "02:00", "r1")
+    assert cached is not None
+    assert cached.available_slots == {"23:00": True, "00:00": True, "01:00": True}
+    assert cached.estimated_price == 30000  # day1(10000) + day2(20000) 누산


### PR DESCRIPTION
closes #279 

## Summary

- `AvailabilityService.prefetch_all()` 메서드 추가: 검색 응답 직후 백그라운드로 전체 룸의 예약 가능 여부를 프리페치하여 캐시를 채움
- `_prefetch_in_flight: set`으로 동일 `(date, start_hour, end_hour)` 조합의 중복 실행 방지
- `app/api/available_room.py` 엔드포인트에 `BackgroundTasks` 파라미터 추가 및 `prefetch_all` 등록
- `tests/services/test_prefetch_all.py`: 7개 단위 테스트 추가

## Key Design Decisions

- **prefetch=True**: `#278`에서 도입한 `_prefetch_semaphore`를 사용하여 프리페치가 재검색 요청을 블로킹하지 않음 (`#278` 머지 이후 완전 동작)
- **DB 조회**: `capacity=1`, 좌표 없음 → 서비스 지역 내 전체 룸 대상
- **중복 방지**: asyncio 단일 스레드 특성 덕분에 `set` 만으로 별도 Lock 없이 안전
- **is_pending() 필터**: 이미 캐시 또는 inflight에 있는 룸은 크롤링 생략
- **overnight 지원**: 심야 예약(start > end)도 day1/day2 슬롯 분리 후 병합하여 캐시 저장

## Test plan

- [ ] `test_prefetch_all_skips_pending_rooms`: 캐시된 룸은 크롤러에 전달 안 됨
- [ ] `test_prefetch_all_prevents_duplicate_execution`: in-flight 중 두 번째 호출은 즉시 반환
- [ ] `test_prefetch_all_early_return_on_db_failure`: DB 실패 시 크롤러 미호출
- [ ] `test_prefetch_all_stores_results_in_cache`: 성공 결과가 캐시에 저장됨
- [ ] `test_prefetch_all_individual_failure_does_not_block_others`: 개별 룸 예외가 다른 룸 저장 안 막음
- [ ] `test_prefetch_all_inflight_cleared_after_completion`: 완료 후 in-flight 키 제거
- [ ] `test_prefetch_all_inflight_cleared_on_db_failure`: DB 실패 후에도 in-flight 키 제거

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Availability checks now schedule a background prefetch to proactively populate the room availability cache, handle overnight/multi-day time ranges, and merge partial results so availability and pricing are more consistent.
* **Tests**
  * Added unit tests for prefetch behavior, overnight ranges, concurrent-request deduplication, error handling, skipping pending rooms, and cache persistence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/summitBandWeb/pick-habju-backend/pull/289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->