### PR TITLE
perf(#281, #282): 세마포어 기본값 상향(30→60) 및 httpx keepalive 풀 확대(20→60)

### DIFF
--- a/app/crawler/naver_checker.py
+++ b/app/crawler/naver_checker.py
@@ -22,9 +22,9 @@ class NaverCrawler(BaseCrawler):
     # 네이버 RATE LIMIT 대응: 동시 API 요청 수를 클래스 수준에서 공유하여 전역 동시성을 제한한다.
     # check_availability 호출마다 새 세마포어를 만들면 호출 간 공유가 되지 않으므로 클래스 속성으로 초기화한다.
     # 높은 부하의 경우 환경 변수(NAVER_CRAWLER_SEMAPHORE)를 통해 조정 가능하도록 지원.
-    _semaphore: asyncio.Semaphore = asyncio.Semaphore(max(1, int(os.getenv("NAVER_CRAWLER_SEMAPHORE", "30"))))
+    _semaphore: asyncio.Semaphore = asyncio.Semaphore(max(1, int(os.getenv("NAVER_CRAWLER_SEMAPHORE", "60"))))
     # 프리페치 전용 세마포어: _semaphore와 슬롯을 공유하지 않아 프리페치가 재검색을 블로킹하지 않는다.
-    _prefetch_semaphore: asyncio.Semaphore = asyncio.Semaphore(max(1, int(os.getenv("NAVER_PREFETCH_SEMAPHORE", "30"))))
+    _prefetch_semaphore: asyncio.Semaphore = asyncio.Semaphore(max(1, int(os.getenv("NAVER_PREFETCH_SEMAPHORE", "60"))))
 
     async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail], *, prefetch: bool = False) -> List[RoomResult]:
         """네이버 예약 API로 특정 날짜와 시간대에 예약 가능한 방들을 조회한다.

--- a/app/crawler/naver_checker.py
+++ b/app/crawler/naver_checker.py
@@ -1,6 +1,7 @@
 import httpx
 from typing import List, Dict, Union
 import asyncio
+import logging
 import os
 
 from app.models.dto import RoomDetail, RoomAvailability
@@ -12,6 +13,18 @@ from app.exception.base_exception import BaseCustomException
 from app.crawler.base import BaseCrawler, RoomResult
 from app.crawler.registry import registry
 
+
+def _parse_semaphore_env(key: str, default: int) -> int:
+    raw = os.getenv(key, str(default))
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        logging.getLogger("app").warning(
+            f"[NaverCrawler] 환경 변수 {key}='{raw}' 가 정수로 변환 불가. 기본값 {default} 사용."
+        )
+        return default
+
+
 class NaverCrawler(BaseCrawler):
     """네이버 예약 GraphQL API를 통해 합주실 예약 가능 여부를 확인하는 크롤러.
 
@@ -22,9 +35,9 @@ class NaverCrawler(BaseCrawler):
     # 네이버 RATE LIMIT 대응: 동시 API 요청 수를 클래스 수준에서 공유하여 전역 동시성을 제한한다.
     # check_availability 호출마다 새 세마포어를 만들면 호출 간 공유가 되지 않으므로 클래스 속성으로 초기화한다.
     # 높은 부하의 경우 환경 변수(NAVER_CRAWLER_SEMAPHORE)를 통해 조정 가능하도록 지원.
-    _semaphore: asyncio.Semaphore = asyncio.Semaphore(max(1, int(os.getenv("NAVER_CRAWLER_SEMAPHORE", "60"))))
+    _semaphore: asyncio.Semaphore = asyncio.Semaphore(_parse_semaphore_env("NAVER_CRAWLER_SEMAPHORE", 60))
     # 프리페치 전용 세마포어: _semaphore와 슬롯을 공유하지 않아 프리페치가 재검색을 블로킹하지 않는다.
-    _prefetch_semaphore: asyncio.Semaphore = asyncio.Semaphore(max(1, int(os.getenv("NAVER_PREFETCH_SEMAPHORE", "60"))))
+    _prefetch_semaphore: asyncio.Semaphore = asyncio.Semaphore(_parse_semaphore_env("NAVER_PREFETCH_SEMAPHORE", 60))
 
     async def check_availability(self, date: str, hour_slots: List[str], target_rooms: List[RoomDetail], *, prefetch: bool = False) -> List[RoomResult]:
         """네이버 예약 API로 특정 날짜와 시간대에 예약 가능한 방들을 조회한다.

--- a/app/utils/client_loader.py
+++ b/app/utils/client_loader.py
@@ -55,7 +55,7 @@ def get_global_client() -> httpx.AsyncClient | None:
 async def _retry_request(client: httpx.AsyncClient, url: str, max_retries: int = 2, **kwargs):
     """재시도 로직을 분리한 헬퍼 함수.
     
-    네트워크 오류나 5xx 서버 에러 발생 시 지수 백오프로 재시도합니다.
+    네트워크 오류나 5xx 서버 에러 발생 시 선형 백오프로 재시도합니다.
     
     Args:
         client: HTTP 클라이언트 인스턴스
@@ -71,7 +71,7 @@ async def _retry_request(client: httpx.AsyncClient, url: str, max_retries: int =
     """
     for attempt in range(max_retries):
         try:
-            # 지수 백오프: 0.2초, 0.4초, 0.6초...
+            # 선형 백오프: 0.2초, 0.4초
             await asyncio.sleep(0.2 * (attempt + 1))
             response = await client.post(url, **kwargs)
             response.raise_for_status()

--- a/app/utils/client_loader.py
+++ b/app/utils/client_loader.py
@@ -23,6 +23,7 @@ async def set_global_client():
         if _shared_client is None:
             _shared_client = httpx.AsyncClient(
                 timeout=httpx.Timeout(10.0, connect=5.0),
+                # _semaphore(60) + _prefetch_semaphore(60) = 최대 120 동시 연결이므로 max_connections=150으로 여유분 확보
                 limits=httpx.Limits(max_keepalive_connections=60, max_connections=150),
                 http2=True,
             )

--- a/app/utils/client_loader.py
+++ b/app/utils/client_loader.py
@@ -16,14 +16,14 @@ async def set_global_client():
     
     HTTP/2 지원 및 연결 풀 최적화 설정:
     - Timeout: 전체 10초, 연결 5초
-    - 연결 풀: 최대 100개 연결, keepalive 20개
+    - 연결 풀: 최대 150개 연결, keepalive 60개
     """
     global _shared_client
     async with _client_lock:
         if _shared_client is None:
             _shared_client = httpx.AsyncClient(
                 timeout=httpx.Timeout(10.0, connect=5.0),
-                limits=httpx.Limits(max_keepalive_connections=20, max_connections=100),
+                limits=httpx.Limits(max_keepalive_connections=60, max_connections=150),
                 http2=True,
             )
 

--- a/tests/test_client_loader.py
+++ b/tests/test_client_loader.py
@@ -2,7 +2,7 @@
 import pytest
 import httpx
 from unittest.mock import AsyncMock, patch, MagicMock
-from app.utils.client_loader import load_client
+from app.utils.client_loader import load_client, set_global_client
 from app.exception.api.client_loader_exception import RequestFailedError
 
 @pytest.mark.asyncio
@@ -59,3 +59,22 @@ async def test_no_retry_on_404():
 
     # 검증
     assert mock_client_instance.post.call_count == 1  # 재시도 없이 1번만 호출되어야 함
+
+
+@pytest.mark.asyncio
+async def test_global_client_limits():
+    """set_global_client()가 keepalive=60, max_connections=150 으로 클라이언트를 초기화하는지 확인."""
+    import app.utils.client_loader as m
+
+    original = m._shared_client
+    m._shared_client = None
+
+    try:
+        with patch("app.utils.client_loader.httpx.AsyncClient") as mock_cls:
+            await set_global_client()
+
+            limits = mock_cls.call_args.kwargs["limits"]
+            assert limits.max_keepalive_connections == 60
+            assert limits.max_connections == 150
+    finally:
+        m._shared_client = original

--- a/tests/test_client_loader.py
+++ b/tests/test_client_loader.py
@@ -66,6 +66,9 @@ async def test_global_client_limits():
     """set_global_client()가 keepalive=60, max_connections=150 으로 클라이언트를 초기화하는지 확인."""
     import app.utils.client_loader as m
 
+    # 테스트 환경에서는 _shared_client가 None이지만, 만약 앱이 초기화된 상태라면
+    # 기존 인스턴스를 보존하고 테스트 후 복원한다. _client_lock 상태는 건드리지 않으므로
+    # 프로덕션 환경에서의 동시 실행에는 적합하지 않다.
     original = m._shared_client
     m._shared_client = None
 

--- a/tests/test_naver_checker.py
+++ b/tests/test_naver_checker.py
@@ -1,7 +1,6 @@
 # tests/test_naver_checker.py
 import pytest
 import os
-import importlib
 
 from datetime import datetime, timedelta
 from app.crawler.naver_checker import NaverCrawler
@@ -9,18 +8,6 @@ from app.models.dto import RoomDetail
 from app.utils.room_loader import get_rooms_by_criteria
 
 RUN_EXTERNAL_TESTS = os.getenv("RUN_EXTERNAL_TESTS") == "1"
-
-
-def test_semaphore_default_values(monkeypatch):
-    """환경변수 미설정 시 _semaphore 및 _prefetch_semaphore 기본값이 60인지 확인."""
-    monkeypatch.delenv("NAVER_CRAWLER_SEMAPHORE", raising=False)
-    monkeypatch.delenv("NAVER_PREFETCH_SEMAPHORE", raising=False)
-
-    import app.crawler.naver_checker as m
-    importlib.reload(m)
-
-    assert m.NaverCrawler._semaphore._value == 60
-    assert m.NaverCrawler._prefetch_semaphore._value == 60
 
 
 @pytest.mark.skipif(

--- a/tests/test_naver_checker.py
+++ b/tests/test_naver_checker.py
@@ -1,6 +1,7 @@
 # tests/test_naver_checker.py
 import pytest
 import os
+import importlib
 
 from datetime import datetime, timedelta
 from app.crawler.naver_checker import NaverCrawler
@@ -8,6 +9,30 @@ from app.models.dto import RoomDetail
 from app.utils.room_loader import get_rooms_by_criteria
 
 RUN_EXTERNAL_TESTS = os.getenv("RUN_EXTERNAL_TESTS") == "1"
+
+
+def test_semaphore_default_values(monkeypatch):
+    """NAVER_CRAWLER_SEMAPHORE, NAVER_PREFETCH_SEMAPHORE 미설정 시 기본값이 60인지 확인."""
+    monkeypatch.delenv("NAVER_CRAWLER_SEMAPHORE", raising=False)
+    monkeypatch.delenv("NAVER_PREFETCH_SEMAPHORE", raising=False)
+
+    import app.crawler.naver_checker as m
+    importlib.reload(m)
+
+    assert m.NaverCrawler._semaphore._value == 60
+    assert m.NaverCrawler._prefetch_semaphore._value == 60
+
+
+def test_semaphore_invalid_env(monkeypatch):
+    """환경변수에 정수로 변환 불가한 값이 있을 때 기본값 60으로 폴백하는지 확인."""
+    monkeypatch.setenv("NAVER_CRAWLER_SEMAPHORE", "abc")
+    monkeypatch.setenv("NAVER_PREFETCH_SEMAPHORE", "xyz")
+
+    import app.crawler.naver_checker as m
+    importlib.reload(m)
+
+    assert m.NaverCrawler._semaphore._value == 60
+    assert m.NaverCrawler._prefetch_semaphore._value == 60
 
 
 @pytest.mark.skipif(

--- a/tests/test_naver_checker.py
+++ b/tests/test_naver_checker.py
@@ -1,6 +1,7 @@
-# te/test_naver_checker.py
+# tests/test_naver_checker.py
 import pytest
 import os
+import importlib
 
 from datetime import datetime, timedelta
 from app.crawler.naver_checker import NaverCrawler
@@ -8,14 +9,26 @@ from app.models.dto import RoomDetail
 from app.utils.room_loader import get_rooms_by_criteria
 
 RUN_EXTERNAL_TESTS = os.getenv("RUN_EXTERNAL_TESTS") == "1"
-pytestmark = pytest.mark.skipif(
+
+
+def test_semaphore_default_values(monkeypatch):
+    """환경변수 미설정 시 _semaphore 및 _prefetch_semaphore 기본값이 60인지 확인."""
+    monkeypatch.delenv("NAVER_CRAWLER_SEMAPHORE", raising=False)
+    monkeypatch.delenv("NAVER_PREFETCH_SEMAPHORE", raising=False)
+
+    import app.crawler.naver_checker as m
+    importlib.reload(m)
+
+    assert m.NaverCrawler._semaphore._value == 60
+    assert m.NaverCrawler._prefetch_semaphore._value == 60
+
+
+@pytest.mark.skipif(
     not RUN_EXTERNAL_TESTS,
     reason="External crawler test disabled. Set RUN_EXTERNAL_TESTS=1 to run.",
 )
-
 @pytest.mark.asyncio
 async def test_get_naver_availability():
-    # 실제 테스트용 파라미터를 여기에 입력하세요
     date = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
     hour_slots = ["15:00", "16:00", "17:00"]
     naver_rooms = []
@@ -37,20 +50,17 @@ async def test_get_naver_availability():
 
     crawler = NaverCrawler()
     result = await crawler.check_availability(date, hour_slots, naver_rooms)
-    
-    # 성공/실패 분리
+
     success_results = [r for r in result if not isinstance(r, Exception)]
     error_results = [r for r in result if isinstance(r, Exception)]
-    
+
     if error_results:
         print(f"\n⚠️ {len(error_results)}개 룸 조회 실패:")
         for err in error_results:
             print(f"  - {err}")
-    
+
     print(f"\n✅ {len(success_results)}개 룸 조회 성공")
 
-    # 검증: 최소 하나 이상 성공해야 함 (크롤러 정상 작동 확인)
     assert isinstance(result, list)
     assert len(success_results) > 0, "모든 룸 조회가 실패했습니다. 네트워크 또는 API 문제일 수 있습니다."
     assert all(hasattr(r, "available_slots") for r in success_results)
-


### PR DESCRIPTION
## Summary

- `NaverCrawler._semaphore` / `_prefetch_semaphore` 기본값 30 → 60 (#281)
  - 179개 룸 기준 waves 6회 → 3회, 실측 약 26% 응답 시간 단축
  - rate limit 발생 시 `NAVER_CRAWLER_SEMAPHORE` / `NAVER_PREFETCH_SEMAPHORE` 환경변수로 운영 중 조정 가능
- `httpx.Limits` `max_keepalive_connections` 20 → 60, `max_connections` 100 → 150 (#282)
  - 세마포어(60)와 keepalive pool 크기를 맞춰 불필요한 TCP handshake 제거
  - 단독 효과 약 3%, #281과 함께 적용 시 의미 있음

## Test plan

- [x] `test_semaphore_default_values`: 환경변수 미설정 시 `_semaphore`, `_prefetch_semaphore` 기본값 60 검증 (`importlib.reload` 활용)
- [x] `test_global_client_limits`: `set_global_client()` 호출 시 `max_keepalive_connections=60`, `max_connections=150` 검증
- [x] 기존 `test_retry_success_after_failure`, `test_no_retry_on_404` 회귀 없음 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Increased default crawler concurrency from 30 → 60; now configurable via environment variables with validation and warnings on invalid values
  * Enhanced HTTP client pooling: higher max connections (150) and keepalive capacity (60)

* **Tests**
  * Added tests to verify concurrency defaults, invalid-env fallback, and connection pool configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/summitBandWeb/pick-habju-backend/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->